### PR TITLE
Add foster_children and adopted_children to geni_union

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,3 +34,8 @@ jobs:
 
       - name: Run tests
         run: make test
+
+      - name: Run linters
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+        with:
+          version: v2.11.4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Run linters
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: latest
+          version: v2.11.4
 
   generate:
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,25 +1,43 @@
-issues:
-  max-issues-per-linter: 0
-  max-same-issues: 0
-
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
+    - copyloopvar
     - durationcheck
     - errcheck
-    - copyloopvar
     - forcetypeassert
     - godot
-    - gofmt
-    - gosimple
+    - govet
     - ineffassign
     - makezero
     - misspell
     - nilerr
     - predeclared
     - staticcheck
-    - usetesting
     - unconvert
     - unparam
     - unused
-    - govet
+    - usetesting
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 0.16.4 (Unreleased)
 
+FEATURES:
+
+* Union: added `foster_children` and `adopted_children` attributes on `geni_union` that map to Geni's `relationship_modifier=foster|adopt` edges. Each child appears in exactly one of `children`, `foster_children`, or `adopted_children`; the three sets must be disjoint. The provider passes the correct modifier through to `AddChild`/`AddSibling` on create and update, and splits the API's subset arrays back out on read so drift surfaces naturally.
+* Union: changing a child's relationship modifier between applies (e.g. moving an id from `foster_children` to `adopted_children`) now emits an attribute warning — Geni has no API to re-tag an existing edge, so the change must be made on Geni.com first.
+
 ## 0.16.3
 
 SECURITY:

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ YELLOW:=\033[0;33m
 WHITE:=\033[0;37m
 NC:=\033[0m # No Color
 
+GOLANGCI_LINT_VERSION := v2.11.4
+GOLANGCI_LINT := bin/golangci-lint
+
 .PHONY: build-local
 build-local:
 	@echo "${WHITE}=====================${NC}"
@@ -37,3 +40,20 @@ docs:
 	@echo "${YELLOW}Generating docs...${NC}"
 	tfplugindocs generate --provider-name geni
 	@echo "${YELLOW}Generating docs...${NC} ${GREEN}Done${NC}"
+
+$(GOLANGCI_LINT):
+	@echo "${WHITE}=====================${NC}"
+	@echo "${YELLOW}Installing golangci-lint ${GOLANGCI_LINT_VERSION}...${NC}"
+	@GOBIN=$(CURDIR)/bin go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+	@echo "${YELLOW}Installing golangci-lint...${NC} ${GREEN}Done${NC}"
+
+.PHONY: lint
+lint: $(GOLANGCI_LINT)
+	@echo "${WHITE}=====================${NC}"
+	@echo "${YELLOW}Linting...${NC}"
+	$(GOLANGCI_LINT) run
+	@echo "${YELLOW}Linting...${NC} ${GREEN}Done${NC}"
+
+.PHONY: lint-fix
+lint-fix: $(GOLANGCI_LINT)
+	$(GOLANGCI_LINT) run --fix

--- a/docs/resources/union.md
+++ b/docs/resources/union.md
@@ -17,8 +17,10 @@ description: |-
 
 ### Optional
 
-- `children` (Set of String) List of children IDs.
+- `adopted_children` (Set of String) List of adopted children IDs. Must be disjoint from children and foster_children.
+- `children` (Set of String) List of biological children IDs. Must be disjoint from foster_children and adopted_children.
 - `divorce` (Attributes) Divorce event information. (see [below for nested schema](#nestedatt--divorce))
+- `foster_children` (Set of String) List of foster children IDs. Must be disjoint from children and adopted_children.
 - `id` (String) The unique identifier for the union. This is a string that starts with 'union-' followed by a number.
 - `marriage` (Attributes) Marriage event information. (see [below for nested schema](#nestedatt--marriage))
 - `partners` (Set of String) List of partner IDs.

--- a/internal/geni/add_options.go
+++ b/internal/geni/add_options.go
@@ -1,0 +1,20 @@
+package geni
+
+import "net/http"
+
+// AddOption modifies an outgoing request for the profile/union add-*
+// endpoints (add-child, add-sibling, add-partner).
+type AddOption func(*http.Request)
+
+// WithModifier sets the relationship_modifier query parameter. An empty
+// value is a no-op.
+func WithModifier(modifier string) AddOption {
+	return func(r *http.Request) {
+		if modifier == "" {
+			return
+		}
+		q := r.URL.Query()
+		q.Set("relationship_modifier", modifier)
+		r.URL.RawQuery = q.Encode()
+	}
+}

--- a/internal/geni/add_options_test.go
+++ b/internal/geni/add_options_test.go
@@ -1,0 +1,47 @@
+package geni
+
+import (
+	"net/http"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestWithModifier(t *testing.T) {
+	t.Run("Sets relationship_modifier when value is non-empty", func(t *testing.T) {
+		RegisterTestingT(t)
+		req, _ := http.NewRequest(http.MethodPost, "https://example.com/api/profile-1/add-child", nil)
+
+		WithModifier("foster")(req)
+
+		Expect(req.URL.Query().Get("relationship_modifier")).To(Equal("foster"))
+	})
+
+	t.Run("Accepts adopt as a valid modifier", func(t *testing.T) {
+		RegisterTestingT(t)
+		req, _ := http.NewRequest(http.MethodPost, "https://example.com/api/profile-1/add-child", nil)
+
+		WithModifier("adopt")(req)
+
+		Expect(req.URL.Query().Get("relationship_modifier")).To(Equal("adopt"))
+	})
+
+	t.Run("Omits the query param when value is empty", func(t *testing.T) {
+		RegisterTestingT(t)
+		req, _ := http.NewRequest(http.MethodPost, "https://example.com/api/profile-1/add-child", nil)
+
+		WithModifier("")(req)
+
+		Expect(req.URL.Query().Has("relationship_modifier")).To(BeFalse())
+	})
+
+	t.Run("Preserves any pre-existing query params", func(t *testing.T) {
+		RegisterTestingT(t)
+		req, _ := http.NewRequest(http.MethodPost, "https://example.com/api/profile-1/add-child?fields=id", nil)
+
+		WithModifier("foster")(req)
+
+		Expect(req.URL.Query().Get("relationship_modifier")).To(Equal("foster"))
+		Expect(req.URL.Query().Get("fields")).To(Equal("id"))
+	})
+}

--- a/internal/geni/profile.go
+++ b/internal/geni/profile.go
@@ -252,7 +252,7 @@ func escapeStringToUTF(s string) string {
 	var sb strings.Builder
 	for _, r := range s {
 		if r > 127 {
-			sb.WriteString(fmt.Sprintf("\\u%04x", r))
+			fmt.Fprintf(&sb, "\\u%04x", r)
 		} else {
 			sb.WriteRune(r)
 		}

--- a/internal/geni/profile.go
+++ b/internal/geni/profile.go
@@ -526,7 +526,7 @@ func (c *Client) AddPartner(ctx context.Context, profileId string) (*ProfileResp
 	return &profile, nil
 }
 
-func (c *Client) AddChild(ctx context.Context, profileId string) (*ProfileResponse, error) {
+func (c *Client) AddChild(ctx context.Context, profileId string, opts ...AddOption) (*ProfileResponse, error) {
 	url := BaseUrl(c.useSandboxEnv) + "api/" + profileId + "/add-child"
 	req, err := http.NewRequest(http.MethodPost, url, nil)
 	if err != nil {
@@ -535,6 +535,9 @@ func (c *Client) AddChild(ctx context.Context, profileId string) (*ProfileRespon
 	}
 
 	c.addProfileFieldsQueryParams(req)
+	for _, opt := range opts {
+		opt(req)
+	}
 
 	body, err := c.doRequest(ctx, req)
 	if err != nil {
@@ -553,7 +556,7 @@ func (c *Client) AddChild(ctx context.Context, profileId string) (*ProfileRespon
 	return &profile, nil
 }
 
-func (c *Client) AddSibling(ctx context.Context, profileId string) (*ProfileResponse, error) {
+func (c *Client) AddSibling(ctx context.Context, profileId string, opts ...AddOption) (*ProfileResponse, error) {
 	url := BaseUrl(c.useSandboxEnv) + "api/" + profileId + "/add-sibling"
 	req, err := http.NewRequest(http.MethodPost, url, nil)
 	if err != nil {
@@ -562,6 +565,9 @@ func (c *Client) AddSibling(ctx context.Context, profileId string) (*ProfileResp
 	}
 
 	c.addProfileFieldsQueryParams(req)
+	for _, opt := range opts {
+		opt(req)
+	}
 
 	body, err := c.doRequest(ctx, req)
 	if err != nil {

--- a/internal/geni/profile_add_test.go
+++ b/internal/geni/profile_add_test.go
@@ -1,0 +1,97 @@
+package geni
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"golang.org/x/oauth2"
+)
+
+type captureTransport struct {
+	lastRequest *http.Request
+}
+
+func (t *captureTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.lastRequest = req.Clone(req.Context())
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(bytes.NewBufferString(`{"id":"profile-tmp"}`)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func newCapturingClient() (*Client, *captureTransport) {
+	ct := &captureTransport{}
+	c := NewClient(oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"}), true)
+	c.client = &http.Client{Transport: ct}
+	return c, ct
+}
+
+func TestAddChild_SendsRelationshipModifier(t *testing.T) {
+	t.Run("With foster modifier sets query param", func(t *testing.T) {
+		RegisterTestingT(t)
+		c, ct := newCapturingClient()
+
+		_, err := c.AddChild(context.Background(), "profile-1", WithModifier("foster"))
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ct.lastRequest).ToNot(BeNil())
+		Expect(ct.lastRequest.URL.Query().Get("relationship_modifier")).To(Equal("foster"))
+	})
+
+	t.Run("With adopt modifier sets query param", func(t *testing.T) {
+		RegisterTestingT(t)
+		c, ct := newCapturingClient()
+
+		_, err := c.AddChild(context.Background(), "profile-1", WithModifier("adopt"))
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ct.lastRequest.URL.Query().Get("relationship_modifier")).To(Equal("adopt"))
+	})
+
+	t.Run("Without options omits the query param", func(t *testing.T) {
+		RegisterTestingT(t)
+		c, ct := newCapturingClient()
+
+		_, err := c.AddChild(context.Background(), "profile-1")
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ct.lastRequest.URL.Query().Has("relationship_modifier")).To(BeFalse())
+	})
+
+	t.Run("Targets the /add-child path for the given id", func(t *testing.T) {
+		RegisterTestingT(t)
+		c, ct := newCapturingClient()
+
+		_, err := c.AddChild(context.Background(), "union-42", WithModifier("foster"))
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ct.lastRequest.URL.Path).To(HaveSuffix("/api/union-42/add-child"))
+	})
+}
+
+func TestAddSibling_SendsRelationshipModifier(t *testing.T) {
+	t.Run("With foster modifier sets query param", func(t *testing.T) {
+		RegisterTestingT(t)
+		c, ct := newCapturingClient()
+
+		_, err := c.AddSibling(context.Background(), "profile-1", WithModifier("foster"))
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ct.lastRequest.URL.Query().Get("relationship_modifier")).To(Equal("foster"))
+	})
+
+	t.Run("Without options omits the query param", func(t *testing.T) {
+		RegisterTestingT(t)
+		c, ct := newCapturingClient()
+
+		_, err := c.AddSibling(context.Background(), "profile-1")
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ct.lastRequest.URL.Query().Has("relationship_modifier")).To(BeFalse())
+	})
+}

--- a/internal/resource/profile/convert.go
+++ b/internal/resource/profile/convert.go
@@ -103,7 +103,7 @@ func NameValueFrom(ctx context.Context, profileNames map[string]geni.NameElement
 		}
 
 		nameModels[locale] = NameModel{
-			FirstName:      types.StringPointerValue(name.FirstName),
+			FirstName:     types.StringPointerValue(name.FirstName),
 			MiddleName:    types.StringPointerValue(name.MiddleName),
 			LastName:      types.StringPointerValue(name.LastName),
 			BirthLastName: types.StringPointerValue(name.MaidenName),

--- a/internal/resource/profile/convert_test.go
+++ b/internal/resource/profile/convert_test.go
@@ -82,7 +82,7 @@ func TestValueFrom(t *testing.T) {
 		var actualNames = make(map[string]NameModel)
 		Expect(actualValue.Names.ElementsAs(t.Context(), &actualNames, false).HasError()).To(BeFalse())
 		Expect(actualNames).To(HaveKeyWithValue("en", NameModel{
-			FirstName:      types.StringPointerValue(givenProfile.Names["en"].FirstName),
+			FirstName:     types.StringPointerValue(givenProfile.Names["en"].FirstName),
 			MiddleName:    types.StringPointerValue(givenProfile.Names["en"].MiddleName),
 			LastName:      types.StringPointerValue(givenProfile.Names["en"].LastName),
 			BirthLastName: types.StringPointerValue(givenProfile.Names["en"].MaidenName),
@@ -221,12 +221,12 @@ func TestUpdateComputedFields(t *testing.T) {
 		}
 
 		model := &ResourceModel{
-			Birth: types.ObjectNull(event.EventModelAttributeTypes()),
-			Baptism: types.ObjectNull(event.EventModelAttributeTypes()),
-			Death:  types.ObjectNull(event.EventModelAttributeTypes()),
-			Burial: types.ObjectNull(event.EventModelAttributeTypes()),
+			Birth:            types.ObjectNull(event.EventModelAttributeTypes()),
+			Baptism:          types.ObjectNull(event.EventModelAttributeTypes()),
+			Death:            types.ObjectNull(event.EventModelAttributeTypes()),
+			Burial:           types.ObjectNull(event.EventModelAttributeTypes()),
 			CurrentResidence: types.ObjectNull(event.LocationModelAttributeTypes()),
-			About: types.MapNull(types.StringType),
+			About:            types.MapNull(types.StringType),
 		}
 
 		diags := UpdateComputedFields(t.Context(), givenProfile, model)
@@ -338,7 +338,7 @@ func TestNameValueFrom(t *testing.T) {
 
 		expectedNames := map[string]NameModel{
 			"en": {
-				FirstName:      types.StringPointerValue(ptr("John")),
+				FirstName:     types.StringPointerValue(ptr("John")),
 				MiddleName:    types.StringPointerValue(ptr("A")),
 				LastName:      types.StringPointerValue(ptr("Doe")),
 				BirthLastName: types.StringPointerValue(ptr("Smith")),
@@ -346,7 +346,7 @@ func TestNameValueFrom(t *testing.T) {
 				Nicknames:     types.SetValueMust(types.StringType, []attr.Value{types.StringValue("A"), types.StringValue("B")}),
 			},
 			"fr": {
-				FirstName:      types.StringPointerValue(ptr("Jean")),
+				FirstName:     types.StringPointerValue(ptr("Jean")),
 				MiddleName:    types.StringPointerValue(ptr("B")),
 				LastName:      types.StringPointerValue(ptr("Dupont")),
 				BirthLastName: types.StringPointerValue(ptr("Bernard")),

--- a/internal/resource/profile/update.go
+++ b/internal/resource/profile/update.go
@@ -77,7 +77,7 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 
 func findRemovedKeys(stateAbout types.Map, planAbout types.Map) []string {
 	removedKeys := []string{}
-	for locale, _ := range stateAbout.Elements() {
+	for locale := range stateAbout.Elements() {
 		if _, ok := planAbout.Elements()[locale]; !ok {
 			removedKeys = append(removedKeys, locale)
 		}

--- a/internal/resource/union/convert.go
+++ b/internal/resource/union/convert.go
@@ -105,6 +105,44 @@ func RequestFrom(ctx context.Context, plan ResourceModel) (*geni.UnionRequest, d
 	return &unionRequest, d
 }
 
+type childModifierChange struct {
+	id   string
+	from string
+	to   string
+}
+
+// childrenWithChangedModifier returns any child ids that exist in both
+// plan and state but moved between the biological / foster / adopted
+// buckets. Geni's public API has no endpoint to change a child's
+// relationship modifier on an existing edge, so these changes cannot be
+// applied and the caller should surface a warning.
+func childrenWithChangedModifier(ctx context.Context, plan, state ResourceModel) []childModifierChange {
+	planLabel := labelsFor(ctx, plan)
+	stateLabel := labelsFor(ctx, state)
+
+	var out []childModifierChange
+	for id, to := range planLabel {
+		if from, ok := stateLabel[id]; ok && from != to {
+			out = append(out, childModifierChange{id: id, from: from, to: to})
+		}
+	}
+	return out
+}
+
+func labelsFor(ctx context.Context, m ResourceModel) map[string]string {
+	labels := make(map[string]string)
+	add := func(set types.Set, label string) {
+		ids, _ := convertToSlice(ctx, set)
+		for _, id := range ids {
+			labels[id] = label
+		}
+	}
+	add(m.Children, "biological")
+	add(m.FosterChildren, "foster")
+	add(m.AdoptedChildren, "adopted")
+	return labels
+}
+
 // modifierFor returns the relationship_modifier value to send when adding
 // childId to a union. "adopt" and "foster" correspond to the matching
 // subset memberships; biological children return "".

--- a/internal/resource/union/convert.go
+++ b/internal/resource/union/convert.go
@@ -17,10 +17,38 @@ func ValueFrom(ctx context.Context, union *geni.UnionResponse, unionModel *Resou
 		unionModel.ID = types.StringValue(union.Id)
 	}
 
+	tagged := make(map[string]struct{}, len(union.FosterChildren)+len(union.AdoptedChildren))
+	for _, id := range union.FosterChildren {
+		tagged[id] = struct{}{}
+	}
+	for _, id := range union.AdoptedChildren {
+		tagged[id] = struct{}{}
+	}
+
 	if len(union.Children) > 0 {
-		children, diags := types.SetValueFrom(ctx, types.StringType, union.Children)
+		biological := make([]string, 0, len(union.Children))
+		for _, id := range union.Children {
+			if _, isTagged := tagged[id]; !isTagged {
+				biological = append(biological, id)
+			}
+		}
+		if len(biological) > 0 {
+			children, diags := types.SetValueFrom(ctx, types.StringType, biological)
+			d.Append(diags...)
+			unionModel.Children = children
+		}
+	}
+
+	if len(union.FosterChildren) > 0 {
+		foster, diags := types.SetValueFrom(ctx, types.StringType, union.FosterChildren)
 		d.Append(diags...)
-		unionModel.Children = children
+		unionModel.FosterChildren = foster
+	}
+
+	if len(union.AdoptedChildren) > 0 {
+		adopted, diags := types.SetValueFrom(ctx, types.StringType, union.AdoptedChildren)
+		d.Append(diags...)
+		unionModel.AdoptedChildren = adopted
 	}
 
 	if len(union.Partners) > 0 {

--- a/internal/resource/union/convert.go
+++ b/internal/resource/union/convert.go
@@ -105,6 +105,19 @@ func RequestFrom(ctx context.Context, plan ResourceModel) (*geni.UnionRequest, d
 	return &unionRequest, d
 }
 
+// modifierFor returns the relationship_modifier value to send when adding
+// childId to a union. "adopt" and "foster" correspond to the matching
+// subset memberships; biological children return "".
+func modifierFor(childId string, fosterChildren, adoptedChildren map[string]struct{}) string {
+	if _, ok := fosterChildren[childId]; ok {
+		return "foster"
+	}
+	if _, ok := adoptedChildren[childId]; ok {
+		return "adopt"
+	}
+	return ""
+}
+
 func hashMapFrom(slice []string) map[string]struct{} {
 	hashMap := make(map[string]struct{}, len(slice))
 	for _, elem := range slice {

--- a/internal/resource/union/convert_test.go
+++ b/internal/resource/union/convert_test.go
@@ -301,6 +301,28 @@ func TestHashMapFrom(t *testing.T) {
 	})
 }
 
+func TestModifierFor(t *testing.T) {
+	RegisterTestingT(t)
+	plan := ResourceModel{
+		Children:        types.SetValueMust(types.StringType, []attr.Value{types.StringValue("bio-1")}),
+		FosterChildren:  types.SetValueMust(types.StringType, []attr.Value{types.StringValue("foster-1")}),
+		AdoptedChildren: types.SetValueMust(types.StringType, []attr.Value{types.StringValue("adopted-1")}),
+	}
+
+	foster, err := convertToSlice(t.Context(), plan.FosterChildren)
+	Expect(err.HasError()).To(BeFalse())
+	adopted, err := convertToSlice(t.Context(), plan.AdoptedChildren)
+	Expect(err.HasError()).To(BeFalse())
+
+	fosterSet := hashMapFrom(foster)
+	adoptedSet := hashMapFrom(adopted)
+
+	Expect(modifierFor("foster-1", fosterSet, adoptedSet)).To(Equal("foster"))
+	Expect(modifierFor("adopted-1", fosterSet, adoptedSet)).To(Equal("adopt"))
+	Expect(modifierFor("bio-1", fosterSet, adoptedSet)).To(Equal(""))
+	Expect(modifierFor("unknown", fosterSet, adoptedSet)).To(Equal(""))
+}
+
 func TestConvertToSlice(t *testing.T) {
 	t.Run("Converts a set to a slice", func(t *testing.T) {
 		RegisterTestingT(t)

--- a/internal/resource/union/convert_test.go
+++ b/internal/resource/union/convert_test.go
@@ -323,6 +323,71 @@ func TestModifierFor(t *testing.T) {
 	Expect(modifierFor("unknown", fosterSet, adoptedSet)).To(Equal(""))
 }
 
+func TestChildrenWithChangedModifier(t *testing.T) {
+	t.Run("Returns empty when plan and state agree", func(t *testing.T) {
+		RegisterTestingT(t)
+		plan := ResourceModel{
+			Children:        types.SetValueMust(types.StringType, []attr.Value{types.StringValue("bio-1")}),
+			FosterChildren:  types.SetValueMust(types.StringType, []attr.Value{types.StringValue("foster-1")}),
+			AdoptedChildren: types.SetValueMust(types.StringType, []attr.Value{types.StringValue("adopted-1")}),
+		}
+		state := plan
+		Expect(childrenWithChangedModifier(t.Context(), plan, state)).To(BeEmpty())
+	})
+
+	t.Run("Flags a child that moved from biological to foster", func(t *testing.T) {
+		RegisterTestingT(t)
+		plan := ResourceModel{
+			Children:        types.SetNull(types.StringType),
+			FosterChildren:  types.SetValueMust(types.StringType, []attr.Value{types.StringValue("kid-1")}),
+			AdoptedChildren: types.SetNull(types.StringType),
+		}
+		state := ResourceModel{
+			Children:        types.SetValueMust(types.StringType, []attr.Value{types.StringValue("kid-1")}),
+			FosterChildren:  types.SetNull(types.StringType),
+			AdoptedChildren: types.SetNull(types.StringType),
+		}
+		moved := childrenWithChangedModifier(t.Context(), plan, state)
+		Expect(moved).To(HaveLen(1))
+		Expect(moved[0].id).To(Equal("kid-1"))
+		Expect(moved[0].from).To(Equal("biological"))
+		Expect(moved[0].to).To(Equal("foster"))
+	})
+
+	t.Run("Flags a child that moved from foster to adopted", func(t *testing.T) {
+		RegisterTestingT(t)
+		plan := ResourceModel{
+			Children:        types.SetNull(types.StringType),
+			FosterChildren:  types.SetNull(types.StringType),
+			AdoptedChildren: types.SetValueMust(types.StringType, []attr.Value{types.StringValue("kid-1")}),
+		}
+		state := ResourceModel{
+			Children:        types.SetNull(types.StringType),
+			FosterChildren:  types.SetValueMust(types.StringType, []attr.Value{types.StringValue("kid-1")}),
+			AdoptedChildren: types.SetNull(types.StringType),
+		}
+		moved := childrenWithChangedModifier(t.Context(), plan, state)
+		Expect(moved).To(HaveLen(1))
+		Expect(moved[0].from).To(Equal("foster"))
+		Expect(moved[0].to).To(Equal("adopted"))
+	})
+
+	t.Run("Does not flag a new child that is not in state", func(t *testing.T) {
+		RegisterTestingT(t)
+		plan := ResourceModel{
+			Children:        types.SetNull(types.StringType),
+			FosterChildren:  types.SetValueMust(types.StringType, []attr.Value{types.StringValue("kid-1")}),
+			AdoptedChildren: types.SetNull(types.StringType),
+		}
+		state := ResourceModel{
+			Children:        types.SetNull(types.StringType),
+			FosterChildren:  types.SetNull(types.StringType),
+			AdoptedChildren: types.SetNull(types.StringType),
+		}
+		Expect(childrenWithChangedModifier(t.Context(), plan, state)).To(BeEmpty())
+	})
+}
+
 func TestConvertToSlice(t *testing.T) {
 	t.Run("Converts a set to a slice", func(t *testing.T) {
 		RegisterTestingT(t)

--- a/internal/resource/union/convert_test.go
+++ b/internal/resource/union/convert_test.go
@@ -98,6 +98,60 @@ func TestValueFrom(t *testing.T) {
 		Expect(model.Marriage.IsNull()).To(BeTrue())
 		Expect(model.Divorce.IsNull()).To(BeTrue())
 	})
+
+	t.Run("Splits API children into biological, foster, and adopted buckets", func(t *testing.T) {
+		RegisterTestingT(t)
+		givenResponse := &geni.UnionResponse{
+			Id:              "union-split",
+			Partners:        []string{"profile-1", "profile-2"},
+			Children:        []string{"profile-3", "profile-4", "profile-5", "profile-6"},
+			FosterChildren:  []string{"profile-4"},
+			AdoptedChildren: []string{"profile-5"},
+		}
+
+		model := &ResourceModel{
+			Children:        types.SetNull(types.StringType),
+			FosterChildren:  types.SetNull(types.StringType),
+			AdoptedChildren: types.SetNull(types.StringType),
+			Partners:        types.SetNull(types.StringType),
+		}
+		diags := ValueFrom(t.Context(), givenResponse, model)
+
+		Expect(diags.HasError()).To(BeFalse())
+
+		bio, d := convertToSlice(t.Context(), model.Children)
+		Expect(d.HasError()).To(BeFalse())
+		Expect(bio).To(ConsistOf("profile-3", "profile-6"))
+
+		foster, d := convertToSlice(t.Context(), model.FosterChildren)
+		Expect(d.HasError()).To(BeFalse())
+		Expect(foster).To(ConsistOf("profile-4"))
+
+		adopted, d := convertToSlice(t.Context(), model.AdoptedChildren)
+		Expect(d.HasError()).To(BeFalse())
+		Expect(adopted).To(ConsistOf("profile-5"))
+	})
+
+	t.Run("Leaves foster and adopted null when the response has no subsets", func(t *testing.T) {
+		RegisterTestingT(t)
+		givenResponse := &geni.UnionResponse{
+			Id:       "union-bio-only",
+			Children: []string{"profile-3"},
+		}
+
+		model := &ResourceModel{
+			Children:        types.SetNull(types.StringType),
+			FosterChildren:  types.SetNull(types.StringType),
+			AdoptedChildren: types.SetNull(types.StringType),
+			Partners:        types.SetNull(types.StringType),
+		}
+		diags := ValueFrom(t.Context(), givenResponse, model)
+
+		Expect(diags.HasError()).To(BeFalse())
+		Expect(model.Children.Elements()).To(HaveLen(1))
+		Expect(model.FosterChildren.IsNull()).To(BeTrue())
+		Expect(model.AdoptedChildren.IsNull()).To(BeTrue())
+	})
 }
 
 func TestUpdateComputedFields(t *testing.T) {

--- a/internal/resource/union/create.go
+++ b/internal/resource/union/create.go
@@ -48,20 +48,39 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 	// Set the children. If the union already exists and has children, we can set
 	// them by calling the union/add-child API. If not, we can use profile/add-child
 	// on a parent profile.
-	if len(plan.Children.Elements()) > 0 {
+	childrenIds, diags := convertToSlice(ctx, plan.Children)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	fosterIds, diags := convertToSlice(ctx, plan.FosterChildren)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	adoptedIds, diags := convertToSlice(ctx, plan.AdoptedChildren)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
-		childrenIds, diags := convertToSlice(ctx, plan.Children)
-		resp.Diagnostics.Append(diags...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
+	allChildrenIds := make([]string, 0, len(childrenIds)+len(fosterIds)+len(adoptedIds))
+	allChildrenIds = append(allChildrenIds, childrenIds...)
+	allChildrenIds = append(allChildrenIds, fosterIds...)
+	allChildrenIds = append(allChildrenIds, adoptedIds...)
 
+	fosterSet := hashMapFrom(fosterIds)
+	adoptedSet := hashMapFrom(adoptedIds)
+
+	if len(allChildrenIds) > 0 {
 		var skipNextIteration bool
-		for i, childId := range childrenIds {
+		for i, childId := range allChildrenIds {
 			if skipNextIteration {
 				skipNextIteration = false
 				continue
 			}
+
+			modifier := modifierFor(childId, fosterSet, adoptedSet)
 
 			var tmpProfile *geni.ProfileResponse
 
@@ -71,7 +90,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 				// we need to create a temporary child profile and then merge it with the
 				// existing child profile.
 				var err error
-				tmpProfile, err = r.client.AddChild(ctx, plan.ID.ValueString())
+				tmpProfile, err = r.client.AddChild(ctx, plan.ID.ValueString(), geni.WithModifier(modifier))
 				if err != nil {
 					resp.Diagnostics.AddAttributeError(path.Root(fieldChildren), "Error adding child with ID="+childId, err.Error())
 					return
@@ -83,19 +102,19 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 					// so we need to create a temporary child profile and then merge it with the
 					// existing child profile.
 					var err error
-					tmpProfile, err = r.client.AddChild(ctx, partnerIds[0])
+					tmpProfile, err = r.client.AddChild(ctx, partnerIds[0], geni.WithModifier(modifier))
 					if err != nil {
 						resp.Diagnostics.AddAttributeError(path.Root(fieldChildren), "Error adding child with ID="+childId, err.Error())
 						return
 					}
-				} else if len(partnerIds) == 0 && len(childrenIds) > 1 {
-					// If there are no partners, we can add a child as a sibling to the first child
-					// in the union using the union/add-sibling API.
+				} else if len(partnerIds) == 0 && len(allChildrenIds) > 1 {
+					// If there are no partners, we can add a child as a sibling to the next child
+					// in the union using the profile/add-sibling API.
 					// It is impossible to add an existing child profile to a sibling using the API,
 					// so we need to create a temporary child profile and then merge it with the
 					// existing child profile.
 					var err error
-					tmpProfile, err = r.client.AddSibling(ctx, childrenIds[i+1])
+					tmpProfile, err = r.client.AddSibling(ctx, allChildrenIds[i+1], geni.WithModifier(modifier))
 					if err != nil {
 						resp.Diagnostics.AddAttributeError(path.Root(fieldChildren), "Error adding child with ID="+childId, err.Error())
 						return

--- a/internal/resource/union/model.go
+++ b/internal/resource/union/model.go
@@ -5,11 +5,13 @@ import (
 )
 
 type ResourceModel struct {
-	ID       types.String `tfsdk:"id"`
-	Children types.Set    `tfsdk:"children"`
-	Partners types.Set    `tfsdk:"partners"`
-	Marriage types.Object `tfsdk:"marriage"`
-	Divorce  types.Object `tfsdk:"divorce"`
+	ID              types.String `tfsdk:"id"`
+	Children        types.Set    `tfsdk:"children"`
+	FosterChildren  types.Set    `tfsdk:"foster_children"`
+	AdoptedChildren types.Set    `tfsdk:"adopted_children"`
+	Partners        types.Set    `tfsdk:"partners"`
+	Marriage        types.Object `tfsdk:"marriage"`
+	Divorce         types.Object `tfsdk:"divorce"`
 }
 
 type ResourceIdentityModel struct {

--- a/internal/resource/union/schema.go
+++ b/internal/resource/union/schema.go
@@ -18,6 +18,8 @@ import (
 
 const fieldPartners = "partners"
 const fieldChildren = "children"
+const fieldFosterChildren = "foster_children"
+const fieldAdoptedChildren = "adopted_children"
 
 var unionIdFormat = regexp.MustCompile(`^union-(g)?\d+$`)
 
@@ -40,7 +42,17 @@ func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *res
 			fieldChildren: schema.SetAttribute{
 				ElementType: types.StringType,
 				Optional:    true,
-				Description: "List of children IDs.",
+				Description: "List of biological children IDs. Must be disjoint from foster_children and adopted_children.",
+			},
+			fieldFosterChildren: schema.SetAttribute{
+				ElementType: types.StringType,
+				Optional:    true,
+				Description: "List of foster children IDs. Must be disjoint from children and adopted_children.",
+			},
+			fieldAdoptedChildren: schema.SetAttribute{
+				ElementType: types.StringType,
+				Optional:    true,
+				Description: "List of adopted children IDs. Must be disjoint from children and foster_children.",
 			},
 			"marriage": event.Schema(event.SchemaOptions{
 				NameComputed:        true,

--- a/internal/resource/union/update.go
+++ b/internal/resource/union/update.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+
+	"github.com/dmalch/terraform-provider-genealogy/internal/geni"
 )
 
 // Update updates the resource.
@@ -73,38 +75,69 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		}
 	}
 
-	// Check if children were updated
-	if !plan.Children.Equal(state.Children) {
-		planChildIds, diags := convertToSlice(ctx, plan.Children)
+	// Check if any of the three child sets were updated
+	if !plan.Children.Equal(state.Children) ||
+		!plan.FosterChildren.Equal(state.FosterChildren) ||
+		!plan.AdoptedChildren.Equal(state.AdoptedChildren) {
+
+		planBio, diags := convertToSlice(ctx, plan.Children)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
 			return
 		}
-		knownPlanChildIds := hashMapFrom(planChildIds)
-
-		stateChildIds, diags := convertToSlice(ctx, state.Children)
+		planFoster, diags := convertToSlice(ctx, plan.FosterChildren)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
 			return
 		}
-		knownStateChildIds := hashMapFrom(stateChildIds)
+		planAdopted, diags := convertToSlice(ctx, plan.AdoptedChildren)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 
-		for _, childId := range stateChildIds {
+		stateBio, diags := convertToSlice(ctx, state.Children)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		stateFoster, diags := convertToSlice(ctx, state.FosterChildren)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		stateAdopted, diags := convertToSlice(ctx, state.AdoptedChildren)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		planAll := append(append(append([]string{}, planBio...), planFoster...), planAdopted...)
+		stateAll := append(append(append([]string{}, stateBio...), stateFoster...), stateAdopted...)
+
+		knownPlanAll := hashMapFrom(planAll)
+		knownStateAll := hashMapFrom(stateAll)
+
+		for _, childId := range stateAll {
 			// If the child is not in the plan, fail the update because we can't remove
 			// children from a union using the API
-			if _, ok := knownPlanChildIds[childId]; !ok {
+			if _, ok := knownPlanAll[childId]; !ok {
 				resp.Diagnostics.AddAttributeWarning(path.Root(fieldChildren), "Cannot remove children", "Children cannot be removed from a union using terraform unless the profile is deleted")
 			}
 		}
 
-		for _, childId := range planChildIds {
+		fosterSet := hashMapFrom(planFoster)
+		adoptedSet := hashMapFrom(planAdopted)
+
+		for _, childId := range planAll {
 			// If the child is not in the state, we need to add it
-			if _, ok := knownStateChildIds[childId]; !ok {
+			if _, ok := knownStateAll[childId]; !ok {
 				// It is impossible to add an existing profile to a union using the API, so we
 				// need to create a temporary profile and then merge it with the existing
 				// profile.
 
-				tmpProfile, err := r.client.AddChild(ctx, plan.ID.ValueString())
+				modifier := modifierFor(childId, fosterSet, adoptedSet)
+				tmpProfile, err := r.client.AddChild(ctx, plan.ID.ValueString(), geni.WithModifier(modifier))
 				if err != nil {
 					resp.Diagnostics.AddAttributeError(path.Root(fieldChildren), "Error adding child with ID="+childId, err.Error())
 					return

--- a/internal/resource/union/update.go
+++ b/internal/resource/union/update.go
@@ -75,6 +75,15 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		}
 	}
 
+	// Warn on modifier changes: Geni has no endpoint to re-tag an existing child.
+	for _, m := range childrenWithChangedModifier(ctx, plan, state) {
+		resp.Diagnostics.AddAttributeWarning(path.Root(fieldChildren),
+			"Cannot change relationship modifier",
+			"Profile "+m.id+" cannot be moved from "+m.from+" to "+m.to+
+				" via the Geni API. Re-tag the relationship on Geni.com, then re-run terraform.",
+		)
+	}
+
 	// Check if any of the three child sets were updated
 	if !plan.Children.Equal(state.Children) ||
 		!plan.FosterChildren.Equal(state.FosterChildren) ||

--- a/internal/resource/union/validator.go
+++ b/internal/resource/union/validator.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 func (r *Resource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
@@ -22,11 +23,57 @@ func (r *Resource) ValidateConfig(ctx context.Context, req resource.ValidateConf
 		)
 	}
 
-	if len(data.Children.Elements())+len(data.Partners.Elements()) < 2 {
+	totalProfiles := len(data.Partners.Elements()) +
+		len(data.Children.Elements()) +
+		len(data.FosterChildren.Elements()) +
+		len(data.AdoptedChildren.Elements())
+	if totalProfiles < 2 {
 		resp.Diagnostics.AddAttributeError(path.Root(fieldPartners),
 			"Insufficient Attribute Configuration",
 			"At least two profiles must be configured in either partners or children. "+
 				"Please ensure that the resource has the required profiles to function correctly.",
 		)
 	}
+
+	childSets := []struct {
+		field string
+		root  path.Path
+		set   types.Set
+	}{
+		{fieldChildren, path.Root(fieldChildren), data.Children},
+		{fieldFosterChildren, path.Root(fieldFosterChildren), data.FosterChildren},
+		{fieldAdoptedChildren, path.Root(fieldAdoptedChildren), data.AdoptedChildren},
+	}
+	for i := 0; i < len(childSets); i++ {
+		left := setIDs(childSets[i].set)
+		for j := i + 1; j < len(childSets); j++ {
+			right := setIDs(childSets[j].set)
+			if id := firstCommon(left, right); id != "" {
+				resp.Diagnostics.AddAttributeError(childSets[j].root,
+					"Overlapping Child Sets",
+					"Profile "+id+" appears in both "+childSets[i].field+" and "+childSets[j].field+". "+
+						"Each child must belong to exactly one relationship category.",
+				)
+			}
+		}
+	}
+}
+
+func setIDs(s types.Set) map[string]struct{} {
+	out := make(map[string]struct{}, len(s.Elements()))
+	for _, e := range s.Elements() {
+		if str, ok := e.(types.String); ok && !str.IsNull() && !str.IsUnknown() {
+			out[str.ValueString()] = struct{}{}
+		}
+	}
+	return out
+}
+
+func firstCommon(a, b map[string]struct{}) string {
+	for id := range a {
+		if _, ok := b[id]; ok {
+			return id
+		}
+	}
+	return ""
 }

--- a/internal/resource/union/validator_test.go
+++ b/internal/resource/union/validator_test.go
@@ -51,7 +51,11 @@ func validatorTestConfigFull(t *testing.T, partners, children, fosterChildren, a
 		Divorce:         types.ObjectNull(event.EventModelAttributeTypes()),
 	}
 
-	objVal, diags := types.ObjectValueFrom(ctx, schemaResp.Schema.Type().(types.ObjectType).AttrTypes, model)
+	objType, ok := schemaResp.Schema.Type().(types.ObjectType)
+	if !ok {
+		t.Fatalf("schema type is not an object: %T", schemaResp.Schema.Type())
+	}
+	objVal, diags := types.ObjectValueFrom(ctx, objType.AttrTypes, model)
 	if diags.HasError() {
 		t.Fatalf("failed to create object value: %v", diags)
 	}

--- a/internal/resource/union/validator_test.go
+++ b/internal/resource/union/validator_test.go
@@ -20,37 +20,35 @@ func testSchema() resource.SchemaResponse {
 }
 
 func validatorTestConfig(t *testing.T, partners []string, children []string) tfsdk.Config {
+	return validatorTestConfigFull(t, partners, children, nil, nil)
+}
+
+func validatorTestConfigFull(t *testing.T, partners, children, fosterChildren, adoptedChildren []string) tfsdk.Config {
 	t.Helper()
 
 	ctx := t.Context()
 	schemaResp := testSchema()
 
-	partnerElems := make([]types.String, len(partners))
-	for i, p := range partners {
-		partnerElems[i] = types.StringValue(p)
-	}
-
-	childElems := make([]types.String, len(children))
-	for i, c := range children {
-		childElems[i] = types.StringValue(c)
-	}
-
-	partnersSet, diags := types.SetValueFrom(ctx, types.StringType, partnerElems)
-	if diags.HasError() {
-		t.Fatalf("failed to create partners set: %v", diags)
-	}
-
-	childrenSet, diags := types.SetValueFrom(ctx, types.StringType, childElems)
-	if diags.HasError() {
-		t.Fatalf("failed to create children set: %v", diags)
+	toSet := func(ids []string, field string) types.Set {
+		elems := make([]types.String, len(ids))
+		for i, id := range ids {
+			elems[i] = types.StringValue(id)
+		}
+		set, diags := types.SetValueFrom(ctx, types.StringType, elems)
+		if diags.HasError() {
+			t.Fatalf("failed to create %s set: %v", field, diags)
+		}
+		return set
 	}
 
 	model := ResourceModel{
-		ID:       types.StringValue("union-1"),
-		Partners: partnersSet,
-		Children: childrenSet,
-		Marriage: types.ObjectNull(event.EventModelAttributeTypes()),
-		Divorce:  types.ObjectNull(event.EventModelAttributeTypes()),
+		ID:              types.StringValue("union-1"),
+		Partners:        toSet(partners, "partners"),
+		Children:        toSet(children, "children"),
+		FosterChildren:  toSet(fosterChildren, "foster_children"),
+		AdoptedChildren: toSet(adoptedChildren, "adopted_children"),
+		Marriage:        types.ObjectNull(event.EventModelAttributeTypes()),
+		Divorce:         types.ObjectNull(event.EventModelAttributeTypes()),
 	}
 
 	objVal, diags := types.ObjectValueFrom(ctx, schemaResp.Schema.Type().(types.ObjectType).AttrTypes, model)
@@ -135,6 +133,105 @@ func TestValidateConfig(t *testing.T) {
 		r := &Resource{}
 		req := resource.ValidateConfigRequest{
 			Config: validatorTestConfig(t, []string{"profile-1"}, []string{"profile-2"}),
+		}
+		resp := &resource.ValidateConfigResponse{}
+
+		r.ValidateConfig(t.Context(), req, resp)
+
+		Expect(resp.Diagnostics.HasError()).To(BeFalse())
+	})
+
+	t.Run("children and foster_children must be disjoint", func(t *testing.T) {
+		RegisterTestingT(t)
+
+		r := &Resource{}
+		req := resource.ValidateConfigRequest{
+			Config: validatorTestConfigFull(t,
+				[]string{"profile-1", "profile-2"},
+				[]string{"profile-3"},
+				[]string{"profile-3"}, // overlap with children
+				nil,
+			),
+		}
+		resp := &resource.ValidateConfigResponse{}
+
+		r.ValidateConfig(t.Context(), req, resp)
+
+		Expect(resp.Diagnostics.HasError()).To(BeTrue())
+		Expect(resp.Diagnostics.Errors()[0].Summary()).To(Equal("Overlapping Child Sets"))
+	})
+
+	t.Run("children and adopted_children must be disjoint", func(t *testing.T) {
+		RegisterTestingT(t)
+
+		r := &Resource{}
+		req := resource.ValidateConfigRequest{
+			Config: validatorTestConfigFull(t,
+				[]string{"profile-1", "profile-2"},
+				[]string{"profile-3"},
+				nil,
+				[]string{"profile-3"}, // overlap with children
+			),
+		}
+		resp := &resource.ValidateConfigResponse{}
+
+		r.ValidateConfig(t.Context(), req, resp)
+
+		Expect(resp.Diagnostics.HasError()).To(BeTrue())
+		Expect(resp.Diagnostics.Errors()[0].Summary()).To(Equal("Overlapping Child Sets"))
+	})
+
+	t.Run("foster_children and adopted_children must be disjoint", func(t *testing.T) {
+		RegisterTestingT(t)
+
+		r := &Resource{}
+		req := resource.ValidateConfigRequest{
+			Config: validatorTestConfigFull(t,
+				[]string{"profile-1", "profile-2"},
+				nil,
+				[]string{"profile-3"},
+				[]string{"profile-3"}, // overlap with foster
+			),
+		}
+		resp := &resource.ValidateConfigResponse{}
+
+		r.ValidateConfig(t.Context(), req, resp)
+
+		Expect(resp.Diagnostics.HasError()).To(BeTrue())
+		Expect(resp.Diagnostics.Errors()[0].Summary()).To(Equal("Overlapping Child Sets"))
+	})
+
+	t.Run("all three child sets disjoint is valid", func(t *testing.T) {
+		RegisterTestingT(t)
+
+		r := &Resource{}
+		req := resource.ValidateConfigRequest{
+			Config: validatorTestConfigFull(t,
+				[]string{"profile-1", "profile-2"},
+				[]string{"profile-3"},
+				[]string{"profile-4"},
+				[]string{"profile-5"},
+			),
+		}
+		resp := &resource.ValidateConfigResponse{}
+
+		r.ValidateConfig(t.Context(), req, resp)
+
+		Expect(resp.Diagnostics.HasError()).To(BeFalse())
+	})
+
+	t.Run("min-2-profiles counts across all child sets", func(t *testing.T) {
+		RegisterTestingT(t)
+
+		r := &Resource{}
+		// 0 partners + 0 children + 1 foster + 1 adopted = 2 profiles → valid
+		req := resource.ValidateConfigRequest{
+			Config: validatorTestConfigFull(t,
+				nil,
+				nil,
+				[]string{"profile-1"},
+				[]string{"profile-2"},
+			),
 		}
 		resp := &resource.ValidateConfigResponse{}
 

--- a/test/acceptance/geni_union_test.go
+++ b/test/acceptance/geni_union_test.go
@@ -1013,3 +1013,112 @@ func unionWithTwoPartnersAndMarriageDetails(year string) string {
 		}
 		`
 }
+
+func TestAccUnion_createUnionWithBiologicalFosterAndAdoptedChildren(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: unionWithBiologicalFosterAndAdoptedChildren(),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("geni_union.doe_family", tfjsonpath.New("partners"), knownvalue.SetSizeExact(2)),
+					statecheck.ExpectKnownValue("geni_union.doe_family", tfjsonpath.New("children"), knownvalue.SetSizeExact(1)),
+					statecheck.ExpectKnownValue("geni_union.doe_family", tfjsonpath.New("foster_children"), knownvalue.SetSizeExact(1)),
+					statecheck.ExpectKnownValue("geni_union.doe_family", tfjsonpath.New("adopted_children"), knownvalue.SetSizeExact(1)),
+					statecheck.CompareValueCollection("geni_union.doe_family", []tfjsonpath.Path{tfjsonpath.New("children")},
+						"geni_profile.bio_child", tfjsonpath.New("id"), compare.ValuesSame()),
+					statecheck.CompareValueCollection("geni_union.doe_family", []tfjsonpath.Path{tfjsonpath.New("foster_children")},
+						"geni_profile.foster_child", tfjsonpath.New("id"), compare.ValuesSame()),
+					statecheck.CompareValueCollection("geni_union.doe_family", []tfjsonpath.Path{tfjsonpath.New("adopted_children")},
+						"geni_profile.adopted_child", tfjsonpath.New("id"), compare.ValuesSame()),
+				},
+			},
+			{
+				// Fresh Read from the API; verifies the sets actually persisted
+				// on Geni rather than being copies of the plan kept in state.
+				ResourceName:      "geni_union.doe_family",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func unionWithBiologicalFosterAndAdoptedChildren() string {
+	return `
+		resource "geni_profile" "husband" {
+		  names = {
+			"en-US" = {
+				first_name = "John"
+				last_name = "Doe"
+			}
+		  }
+		  alive = false
+		  public = true
+		}
+
+		resource "geni_profile" "wife" {
+		  names = {
+			"en-US" = {
+				first_name = "Jane"
+				last_name = "Doe"
+			}
+		  }
+		  alive = false
+		  public = true
+		}
+
+		resource "geni_profile" "bio_child" {
+		  names = {
+			"en-US" = {
+				first_name = "Alice"
+				last_name = "Doe"
+			}
+		  }
+		  alive = false
+		  public = true
+		}
+
+		resource "geni_profile" "foster_child" {
+		  names = {
+			"en-US" = {
+				first_name = "Bob"
+				last_name = "Doe"
+			}
+		  }
+		  alive = false
+		  public = true
+		}
+
+		resource "geni_profile" "adopted_child" {
+		  names = {
+			"en-US" = {
+				first_name = "Carol"
+				last_name = "Doe"
+			}
+		  }
+		  alive = false
+		  public = true
+		}
+
+		resource "geni_union" "doe_family" {
+		  partners = [
+			geni_profile.husband.id,
+			geni_profile.wife.id,
+		  ]
+
+		  children = [
+			geni_profile.bio_child.id,
+		  ]
+
+		  foster_children = [
+			geni_profile.foster_child.id,
+		  ]
+
+		  adopted_children = [
+			geni_profile.adopted_child.id,
+		  ]
+		}
+		`
+}

--- a/test/acceptance/geni_union_test.go
+++ b/test/acceptance/geni_union_test.go
@@ -1122,3 +1122,65 @@ func unionWithBiologicalFosterAndAdoptedChildren() string {
 		}
 		`
 }
+
+func TestAccUnion_addFosterChildToExistingUnion(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: create union with one biological child
+				Config: unionWithTwoPartnersAndChild(),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("geni_union.doe_family", tfjsonpath.New("partners"), knownvalue.SetSizeExact(2)),
+					statecheck.ExpectKnownValue("geni_union.doe_family", tfjsonpath.New("children"), knownvalue.SetSizeExact(1)),
+				},
+			},
+			{
+				// Step 2: add a foster child to the existing union
+				Config: `
+				resource "geni_profile" "husband" {
+				  names = { "en-US" = { first_name = "John", last_name = "Doe" } }
+				  alive = false
+				  public = true
+				}
+
+				resource "geni_profile" "wife" {
+				  names = { "en-US" = { first_name = "Jane", last_name = "Doe" } }
+				  alive = false
+				  public = true
+				}
+
+				resource "geni_profile" "child" {
+				  names = { "en-US" = { first_name = "Alice", last_name = "Doe" } }
+				  alive = false
+				  public = true
+				}
+
+				resource "geni_profile" "foster" {
+				  names = { "en-US" = { first_name = "Dan", last_name = "Doe" } }
+				  alive = false
+				  public = true
+				}
+
+				resource "geni_union" "doe_family" {
+				  partners = [geni_profile.husband.id, geni_profile.wife.id]
+				  children = [geni_profile.child.id]
+				  foster_children = [geni_profile.foster.id]
+				}
+				`,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("geni_union.doe_family", tfjsonpath.New("children"), knownvalue.SetSizeExact(1)),
+					statecheck.ExpectKnownValue("geni_union.doe_family", tfjsonpath.New("foster_children"), knownvalue.SetSizeExact(1)),
+					statecheck.CompareValueCollection("geni_union.doe_family", []tfjsonpath.Path{tfjsonpath.New("foster_children")},
+						"geni_profile.foster", tfjsonpath.New("id"), compare.ValuesSame()),
+				},
+			},
+			{
+				ResourceName:      "geni_union.doe_family",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Summary

- `geni_union` now accepts `foster_children` and `adopted_children` alongside `children`. Each child appears in exactly one of the three sets; the validator rejects overlaps.
- Provider translates between the Terraform shape (three disjoint sets) and the Geni API shape (`adopted_children` / `foster_children` are subsets of `children`) on both read and write. On write it forwards `relationship_modifier=adopt|foster` to `AddChild` / `AddSibling`; on read it subtracts the tagged ids from `children` so state reflects the user-facing shape.
- Geni has no API to re-tag an existing child edge, so moving an id between the three sets emits an attribute warning directing the user to fix the relationship on Geni.com — matching today's "cannot remove children" pattern.

Built test-first: each commit is a single Red → Green cycle (unit tests for client options, validator, converter, modifier helper; acceptance tests for create and update paths — both acceptance cases use `ImportState` + `ImportStateVerify` so drift against real API state is caught).

## Test plan

- [x] `go test ./internal/... -count=1` — all green locally
- [x] `TF_ACC=1 go test -run TestAccUnion_createUnionWithBiologicalFosterAndAdoptedChildren -v ./test/acceptance/` — pass
- [x] `TF_ACC=1 go test -run TestAccUnion_addFosterChildToExistingUnion -v ./test/acceptance/` — pass
- [x] Full `TF_ACC=1 go test -run TestAccUnion -v ./test/acceptance/` pass (one unrelated flaky test — `TestAccUnion_createUnionWithTwoPartnersAndDetails`, marriage-name ordering — passed on retry)
- [x] `make docs` regenerates `docs/resources/union.md` with the two new attributes