### PR TITLE
Fix batch-read zombie state and validate IDs on import (#80)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,8 +49,16 @@ golangci-lint run
 - Acceptance tests are in `test/acceptance/` and require `TF_ACC=1`
 - Tests use `terraform-plugin-testing` framework with `ProtoV6ProviderFactories`
 - A valid access token must be set in `test/acceptance/const_test.go` to run acceptance tests
-- Unit tests for conversion logic live alongside implementation (e.g., `internal/resource/profile/convert_test.go`)
+- Unit tests live alongside implementation (e.g., `internal/resource/profile/convert_test.go`)
 - CI runs acceptance tests against Terraform 1.11.x with a 10-minute timeout
+
+### Unit test conventions
+
+- Use `gomega` with a dot-import: `. "github.com/onsi/gomega"` and `Expect(...).To(...)` matchers — not `testify` or bare `t.Fatal`.
+- Name the top-level test after the function under test (e.g. `TestValueFrom`, `TestResolveDocumentImport`); use `t.Run("Behavioral scenario description", ...)` for each case.
+- Call `RegisterTestingT(t)` at the start of every `t.Run` sub-test (Gomega needs it per goroutine).
+- Use `t.Context()` rather than `context.Background()`.
+- Tests live in the same package as the code under test (no `_test` package) so unexported domain functions are directly callable.
 
 ## Linting
 

--- a/internal/genibatch/batch_client.go
+++ b/internal/genibatch/batch_client.go
@@ -256,17 +256,25 @@ func (c *Client) processBatchOfUnions(ctx context.Context, batch []unionAsyncReq
 			return
 		}
 
-		idToResponse := make(map[string]*geni.UnionResponse)
-		for _, result := range res.Results {
-			idToResponse[result.Id] = &result
-		}
+		fulfillUnionRequests(batch, res.Results)
+	}
+}
 
-		for _, req := range batch {
-			if result, ok := idToResponse[req.Id]; ok {
-				req.Response <- result
-			} else {
-				req.Error <- fmt.Errorf("union %s not found in the response", req.Id)
-			}
+// fulfillUnionRequests dispatches per-request results from a bulk union response.
+// IDs absent from the bulk results are treated as not-found, because the Geni bulk
+// endpoint silently omits missing IDs from its response — that absence is the domain
+// signal that the union no longer exists.
+func fulfillUnionRequests(batch []unionAsyncRequest, results []geni.UnionResponse) {
+	idToResponse := make(map[string]*geni.UnionResponse, len(results))
+	for i := range results {
+		idToResponse[results[i].Id] = &results[i]
+	}
+
+	for _, req := range batch {
+		if result, ok := idToResponse[req.Id]; ok {
+			req.Response <- result
+		} else {
+			req.Error <- fmt.Errorf("union %s not found in the response: %w", req.Id, geni.ErrResourceNotFound)
 		}
 	}
 }
@@ -307,17 +315,24 @@ func (c *Client) processBatchOfProfiles(ctx context.Context, batch []profileAsyn
 			return
 		}
 
-		idToResponse := make(map[string]*geni.ProfileResponse)
-		for _, result := range res.Results {
-			idToResponse[result.Id] = &result
-		}
+		fulfillProfileRequests(batch, res.Results)
+	}
+}
 
-		for _, req := range batch {
-			if result, ok := idToResponse[req.Id]; ok {
-				req.Response <- result
-			} else {
-				req.Error <- fmt.Errorf("profile %s not found in the response", req.Id)
-			}
+// fulfillProfileRequests dispatches per-request results from a bulk profile response.
+// IDs absent from the bulk results are treated as not-found, because the Geni bulk
+// endpoint silently omits missing IDs from its response.
+func fulfillProfileRequests(batch []profileAsyncRequest, results []geni.ProfileResponse) {
+	idToResponse := make(map[string]*geni.ProfileResponse, len(results))
+	for i := range results {
+		idToResponse[results[i].Id] = &results[i]
+	}
+
+	for _, req := range batch {
+		if result, ok := idToResponse[req.Id]; ok {
+			req.Response <- result
+		} else {
+			req.Error <- fmt.Errorf("profile %s not found in the response: %w", req.Id, geni.ErrResourceNotFound)
 		}
 	}
 }
@@ -358,17 +373,24 @@ func (c *Client) processBatchOfDocuments(ctx context.Context, batch []documentAs
 			return
 		}
 
-		idToResponse := make(map[string]*geni.DocumentResponse)
-		for _, result := range res.Results {
-			idToResponse[result.Id] = &result
-		}
+		fulfillDocumentRequests(batch, res.Results)
+	}
+}
 
-		for _, req := range batch {
-			if result, ok := idToResponse[req.Id]; ok {
-				req.Response <- result
-			} else {
-				req.Error <- fmt.Errorf("document %s not found in the response", req.Id)
-			}
+// fulfillDocumentRequests dispatches per-request results from a bulk document response.
+// IDs absent from the bulk results are treated as not-found, because the Geni bulk
+// endpoint silently omits missing IDs from its response.
+func fulfillDocumentRequests(batch []documentAsyncRequest, results []geni.DocumentResponse) {
+	idToResponse := make(map[string]*geni.DocumentResponse, len(results))
+	for i := range results {
+		idToResponse[results[i].Id] = &results[i]
+	}
+
+	for _, req := range batch {
+		if result, ok := idToResponse[req.Id]; ok {
+			req.Response <- result
+		} else {
+			req.Error <- fmt.Errorf("document %s not found in the response: %w", req.Id, geni.ErrResourceNotFound)
 		}
 	}
 }

--- a/internal/genibatch/batch_client_test.go
+++ b/internal/genibatch/batch_client_test.go
@@ -4,96 +4,88 @@ import (
 	"errors"
 	"testing"
 
+	. "github.com/onsi/gomega"
+
 	"github.com/dmalch/terraform-provider-genealogy/internal/geni"
 )
 
-func TestFulfillDocumentRequests_MissingIDReturnsResourceNotFound(t *testing.T) {
-	missing := documentAsyncRequest{
-		Id:       "document-missing",
-		Response: make(chan *geni.DocumentResponse, 1),
-		Error:    make(chan error, 1),
-	}
-
-	fulfillDocumentRequests([]documentAsyncRequest{missing}, nil)
-
-	select {
-	case err := <-missing.Error:
-		if !errors.Is(err, geni.ErrResourceNotFound) {
-			t.Fatalf("expected error to wrap geni.ErrResourceNotFound, got: %v", err)
+func TestFulfillDocumentRequests(t *testing.T) {
+	t.Run("Missing ID in bulk response surfaces ErrResourceNotFound", func(t *testing.T) {
+		RegisterTestingT(t)
+		missing := documentAsyncRequest{
+			Id:       "document-missing",
+			Response: make(chan *geni.DocumentResponse, 1),
+			Error:    make(chan error, 1),
 		}
-	case <-missing.Response:
-		t.Fatal("expected error on missing ID, got a response")
-	}
+
+		fulfillDocumentRequests([]documentAsyncRequest{missing}, nil)
+
+		Expect(missing.Response).ToNot(Receive())
+		var err error
+		Expect(missing.Error).To(Receive(&err))
+		Expect(errors.Is(err, geni.ErrResourceNotFound)).To(BeTrue())
+	})
+
+	t.Run("Mixed hits and misses route each request correctly", func(t *testing.T) {
+		RegisterTestingT(t)
+		hit := documentAsyncRequest{
+			Id:       "document-hit",
+			Response: make(chan *geni.DocumentResponse, 1),
+			Error:    make(chan error, 1),
+		}
+		miss := documentAsyncRequest{
+			Id:       "document-miss",
+			Response: make(chan *geni.DocumentResponse, 1),
+			Error:    make(chan error, 1),
+		}
+
+		fulfillDocumentRequests(
+			[]documentAsyncRequest{hit, miss},
+			[]geni.DocumentResponse{{Id: "document-hit", Title: "found"}},
+		)
+
+		var hitResp *geni.DocumentResponse
+		Expect(hit.Response).To(Receive(&hitResp))
+		Expect(hitResp.Id).To(Equal("document-hit"))
+		Expect(hit.Error).ToNot(Receive())
+
+		var missErr error
+		Expect(miss.Error).To(Receive(&missErr))
+		Expect(errors.Is(missErr, geni.ErrResourceNotFound)).To(BeTrue())
+		Expect(miss.Response).ToNot(Receive())
+	})
 }
 
-func TestFulfillDocumentRequests_MixedHitsAndMisses(t *testing.T) {
-	hit := documentAsyncRequest{
-		Id:       "document-hit",
-		Response: make(chan *geni.DocumentResponse, 1),
-		Error:    make(chan error, 1),
-	}
-	miss := documentAsyncRequest{
-		Id:       "document-miss",
-		Response: make(chan *geni.DocumentResponse, 1),
-		Error:    make(chan error, 1),
-	}
-
-	results := []geni.DocumentResponse{{Id: "document-hit", Title: "found"}}
-	fulfillDocumentRequests([]documentAsyncRequest{hit, miss}, results)
-
-	select {
-	case res := <-hit.Response:
-		if res == nil || res.Id != "document-hit" {
-			t.Fatalf("expected hit response with Id=document-hit, got: %#v", res)
+func TestFulfillUnionRequests(t *testing.T) {
+	t.Run("Missing ID in bulk response surfaces ErrResourceNotFound", func(t *testing.T) {
+		RegisterTestingT(t)
+		missing := unionAsyncRequest{
+			Id:       "union-missing",
+			Response: make(chan *geni.UnionResponse, 1),
+			Error:    make(chan error, 1),
 		}
-	case err := <-hit.Error:
-		t.Fatalf("expected response for hit, got error: %v", err)
-	}
 
-	select {
-	case err := <-miss.Error:
-		if !errors.Is(err, geni.ErrResourceNotFound) {
-			t.Fatalf("expected miss error to wrap geni.ErrResourceNotFound, got: %v", err)
-		}
-	case <-miss.Response:
-		t.Fatal("expected error for miss, got a response")
-	}
+		fulfillUnionRequests([]unionAsyncRequest{missing}, nil)
+
+		var err error
+		Expect(missing.Error).To(Receive(&err))
+		Expect(errors.Is(err, geni.ErrResourceNotFound)).To(BeTrue())
+	})
 }
 
-func TestFulfillUnionRequests_MissingIDReturnsResourceNotFound(t *testing.T) {
-	missing := unionAsyncRequest{
-		Id:       "union-missing",
-		Response: make(chan *geni.UnionResponse, 1),
-		Error:    make(chan error, 1),
-	}
-
-	fulfillUnionRequests([]unionAsyncRequest{missing}, nil)
-
-	select {
-	case err := <-missing.Error:
-		if !errors.Is(err, geni.ErrResourceNotFound) {
-			t.Fatalf("expected error to wrap geni.ErrResourceNotFound, got: %v", err)
+func TestFulfillProfileRequests(t *testing.T) {
+	t.Run("Missing ID in bulk response surfaces ErrResourceNotFound", func(t *testing.T) {
+		RegisterTestingT(t)
+		missing := profileAsyncRequest{
+			Id:       "profile-missing",
+			Response: make(chan *geni.ProfileResponse, 1),
+			Error:    make(chan error, 1),
 		}
-	case <-missing.Response:
-		t.Fatal("expected error on missing ID, got a response")
-	}
-}
 
-func TestFulfillProfileRequests_MissingIDReturnsResourceNotFound(t *testing.T) {
-	missing := profileAsyncRequest{
-		Id:       "profile-missing",
-		Response: make(chan *geni.ProfileResponse, 1),
-		Error:    make(chan error, 1),
-	}
+		fulfillProfileRequests([]profileAsyncRequest{missing}, nil)
 
-	fulfillProfileRequests([]profileAsyncRequest{missing}, nil)
-
-	select {
-	case err := <-missing.Error:
-		if !errors.Is(err, geni.ErrResourceNotFound) {
-			t.Fatalf("expected error to wrap geni.ErrResourceNotFound, got: %v", err)
-		}
-	case <-missing.Response:
-		t.Fatal("expected error on missing ID, got a response")
-	}
+		var err error
+		Expect(missing.Error).To(Receive(&err))
+		Expect(errors.Is(err, geni.ErrResourceNotFound)).To(BeTrue())
+	})
 }

--- a/internal/genibatch/batch_client_test.go
+++ b/internal/genibatch/batch_client_test.go
@@ -1,0 +1,99 @@
+package genibatch
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/dmalch/terraform-provider-genealogy/internal/geni"
+)
+
+func TestFulfillDocumentRequests_MissingIDReturnsResourceNotFound(t *testing.T) {
+	missing := documentAsyncRequest{
+		Id:       "document-missing",
+		Response: make(chan *geni.DocumentResponse, 1),
+		Error:    make(chan error, 1),
+	}
+
+	fulfillDocumentRequests([]documentAsyncRequest{missing}, nil)
+
+	select {
+	case err := <-missing.Error:
+		if !errors.Is(err, geni.ErrResourceNotFound) {
+			t.Fatalf("expected error to wrap geni.ErrResourceNotFound, got: %v", err)
+		}
+	case <-missing.Response:
+		t.Fatal("expected error on missing ID, got a response")
+	}
+}
+
+func TestFulfillDocumentRequests_MixedHitsAndMisses(t *testing.T) {
+	hit := documentAsyncRequest{
+		Id:       "document-hit",
+		Response: make(chan *geni.DocumentResponse, 1),
+		Error:    make(chan error, 1),
+	}
+	miss := documentAsyncRequest{
+		Id:       "document-miss",
+		Response: make(chan *geni.DocumentResponse, 1),
+		Error:    make(chan error, 1),
+	}
+
+	results := []geni.DocumentResponse{{Id: "document-hit", Title: "found"}}
+	fulfillDocumentRequests([]documentAsyncRequest{hit, miss}, results)
+
+	select {
+	case res := <-hit.Response:
+		if res == nil || res.Id != "document-hit" {
+			t.Fatalf("expected hit response with Id=document-hit, got: %#v", res)
+		}
+	case err := <-hit.Error:
+		t.Fatalf("expected response for hit, got error: %v", err)
+	}
+
+	select {
+	case err := <-miss.Error:
+		if !errors.Is(err, geni.ErrResourceNotFound) {
+			t.Fatalf("expected miss error to wrap geni.ErrResourceNotFound, got: %v", err)
+		}
+	case <-miss.Response:
+		t.Fatal("expected error for miss, got a response")
+	}
+}
+
+func TestFulfillUnionRequests_MissingIDReturnsResourceNotFound(t *testing.T) {
+	missing := unionAsyncRequest{
+		Id:       "union-missing",
+		Response: make(chan *geni.UnionResponse, 1),
+		Error:    make(chan error, 1),
+	}
+
+	fulfillUnionRequests([]unionAsyncRequest{missing}, nil)
+
+	select {
+	case err := <-missing.Error:
+		if !errors.Is(err, geni.ErrResourceNotFound) {
+			t.Fatalf("expected error to wrap geni.ErrResourceNotFound, got: %v", err)
+		}
+	case <-missing.Response:
+		t.Fatal("expected error on missing ID, got a response")
+	}
+}
+
+func TestFulfillProfileRequests_MissingIDReturnsResourceNotFound(t *testing.T) {
+	missing := profileAsyncRequest{
+		Id:       "profile-missing",
+		Response: make(chan *geni.ProfileResponse, 1),
+		Error:    make(chan error, 1),
+	}
+
+	fulfillProfileRequests([]profileAsyncRequest{missing}, nil)
+
+	select {
+	case err := <-missing.Error:
+		if !errors.Is(err, geni.ErrResourceNotFound) {
+			t.Fatalf("expected error to wrap geni.ErrResourceNotFound, got: %v", err)
+		}
+	case <-missing.Response:
+		t.Fatal("expected error on missing ID, got a response")
+	}
+}

--- a/internal/resource/document/import_test.go
+++ b/internal/resource/document/import_test.go
@@ -5,51 +5,45 @@ import (
 	"errors"
 	"testing"
 
+	. "github.com/onsi/gomega"
+
 	"github.com/dmalch/terraform-provider-genealogy/internal/geni"
 )
 
-func TestResolveDocumentImport_NotFoundProducesError(t *testing.T) {
-	fetch := func(_ context.Context, _ string) (*geni.DocumentResponse, error) {
-		return nil, geni.ErrResourceNotFound
-	}
+func TestResolveDocumentImport(t *testing.T) {
+	t.Run("Not-found from fetch produces an error diagnostic", func(t *testing.T) {
+		RegisterTestingT(t)
+		fetch := func(_ context.Context, _ string) (*geni.DocumentResponse, error) {
+			return nil, geni.ErrResourceNotFound
+		}
 
-	_, _, diags := resolveDocumentImport(context.Background(), "document-missing", fetch)
+		_, _, diags := resolveDocumentImport(t.Context(), "document-missing", fetch)
 
-	if !diags.HasError() {
-		t.Fatal("expected error diagnostic when fetch returns ErrResourceNotFound, got none")
-	}
-}
+		Expect(diags.HasError()).To(BeTrue())
+	})
 
-func TestResolveDocumentImport_TransportErrorSurfaced(t *testing.T) {
-	sentinel := errors.New("network exploded")
-	fetch := func(_ context.Context, _ string) (*geni.DocumentResponse, error) {
-		return nil, sentinel
-	}
+	t.Run("Transport error is surfaced as an error diagnostic", func(t *testing.T) {
+		RegisterTestingT(t)
+		fetch := func(_ context.Context, _ string) (*geni.DocumentResponse, error) {
+			return nil, errors.New("network exploded")
+		}
 
-	_, _, diags := resolveDocumentImport(context.Background(), "document-x", fetch)
+		_, _, diags := resolveDocumentImport(t.Context(), "document-x", fetch)
 
-	if !diags.HasError() {
-		t.Fatal("expected error diagnostic when fetch returns a non-not-found error, got none")
-	}
-}
+		Expect(diags.HasError()).To(BeTrue())
+	})
 
-func TestResolveDocumentImport_HappyPathPopulatesStateAndIdentity(t *testing.T) {
-	fetch := func(_ context.Context, id string) (*geni.DocumentResponse, error) {
-		return &geni.DocumentResponse{Id: id, Title: "My Doc"}, nil
-	}
+	t.Run("Happy path populates state and identity from the fetched response", func(t *testing.T) {
+		RegisterTestingT(t)
+		fetch := func(_ context.Context, id string) (*geni.DocumentResponse, error) {
+			return &geni.DocumentResponse{Id: id, Title: "My Doc"}, nil
+		}
 
-	state, identity, diags := resolveDocumentImport(context.Background(), "document-42", fetch)
+		state, identity, diags := resolveDocumentImport(t.Context(), "document-42", fetch)
 
-	if diags.HasError() {
-		t.Fatalf("expected no diagnostics on happy path, got: %v", diags)
-	}
-	if identity.ID.ValueString() != "document-42" {
-		t.Fatalf("expected identity.ID=document-42, got %q", identity.ID.ValueString())
-	}
-	if state.ID.ValueString() != "document-42" {
-		t.Fatalf("expected state.ID=document-42, got %q", state.ID.ValueString())
-	}
-	if state.Title.ValueString() != "My Doc" {
-		t.Fatalf("expected state.Title=My Doc, got %q", state.Title.ValueString())
-	}
+		Expect(diags.HasError()).To(BeFalse())
+		Expect(identity.ID.ValueString()).To(Equal("document-42"))
+		Expect(state.ID.ValueString()).To(Equal("document-42"))
+		Expect(state.Title.ValueString()).To(Equal("My Doc"))
+	})
 }

--- a/internal/resource/document/import_test.go
+++ b/internal/resource/document/import_test.go
@@ -1,0 +1,55 @@
+package document
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/dmalch/terraform-provider-genealogy/internal/geni"
+)
+
+func TestResolveDocumentImport_NotFoundProducesError(t *testing.T) {
+	fetch := func(_ context.Context, _ string) (*geni.DocumentResponse, error) {
+		return nil, geni.ErrResourceNotFound
+	}
+
+	_, _, diags := resolveDocumentImport(context.Background(), "document-missing", fetch)
+
+	if !diags.HasError() {
+		t.Fatal("expected error diagnostic when fetch returns ErrResourceNotFound, got none")
+	}
+}
+
+func TestResolveDocumentImport_TransportErrorSurfaced(t *testing.T) {
+	sentinel := errors.New("network exploded")
+	fetch := func(_ context.Context, _ string) (*geni.DocumentResponse, error) {
+		return nil, sentinel
+	}
+
+	_, _, diags := resolveDocumentImport(context.Background(), "document-x", fetch)
+
+	if !diags.HasError() {
+		t.Fatal("expected error diagnostic when fetch returns a non-not-found error, got none")
+	}
+}
+
+func TestResolveDocumentImport_HappyPathPopulatesStateAndIdentity(t *testing.T) {
+	fetch := func(_ context.Context, id string) (*geni.DocumentResponse, error) {
+		return &geni.DocumentResponse{Id: id, Title: "My Doc"}, nil
+	}
+
+	state, identity, diags := resolveDocumentImport(context.Background(), "document-42", fetch)
+
+	if diags.HasError() {
+		t.Fatalf("expected no diagnostics on happy path, got: %v", diags)
+	}
+	if identity.ID.ValueString() != "document-42" {
+		t.Fatalf("expected identity.ID=document-42, got %q", identity.ID.ValueString())
+	}
+	if state.ID.ValueString() != "document-42" {
+		t.Fatalf("expected state.ID=document-42, got %q", state.ID.ValueString())
+	}
+	if state.Title.ValueString() != "My Doc" {
+		t.Fatalf("expected state.Title=My Doc, got %q", state.Title.ValueString())
+	}
+}

--- a/internal/resource/document/import_test.go
+++ b/internal/resource/document/import_test.go
@@ -10,14 +10,14 @@ import (
 	"github.com/dmalch/terraform-provider-genealogy/internal/geni"
 )
 
-func TestResolveDocumentImport(t *testing.T) {
+func TestValidateDocumentImportID(t *testing.T) {
 	t.Run("Not-found from fetch produces an error diagnostic", func(t *testing.T) {
 		RegisterTestingT(t)
 		fetch := func(_ context.Context, _ string) (*geni.DocumentResponse, error) {
 			return nil, geni.ErrResourceNotFound
 		}
 
-		_, _, diags := resolveDocumentImport(t.Context(), "document-missing", fetch)
+		diags := validateDocumentImportID(t.Context(), "document-missing", fetch)
 
 		Expect(diags.HasError()).To(BeTrue())
 	})
@@ -28,22 +28,30 @@ func TestResolveDocumentImport(t *testing.T) {
 			return nil, errors.New("network exploded")
 		}
 
-		_, _, diags := resolveDocumentImport(t.Context(), "document-x", fetch)
+		diags := validateDocumentImportID(t.Context(), "document-x", fetch)
 
 		Expect(diags.HasError()).To(BeTrue())
 	})
 
-	t.Run("Happy path populates state and identity from the fetched response", func(t *testing.T) {
+	t.Run("Empty response Id is treated as not-found", func(t *testing.T) {
 		RegisterTestingT(t)
-		fetch := func(_ context.Context, id string) (*geni.DocumentResponse, error) {
-			return &geni.DocumentResponse{Id: id, Title: "My Doc"}, nil
+		fetch := func(_ context.Context, _ string) (*geni.DocumentResponse, error) {
+			return &geni.DocumentResponse{}, nil
 		}
 
-		state, identity, diags := resolveDocumentImport(t.Context(), "document-42", fetch)
+		diags := validateDocumentImportID(t.Context(), "document-missing", fetch)
+
+		Expect(diags.HasError()).To(BeTrue())
+	})
+
+	t.Run("Successful fetch yields no diagnostics", func(t *testing.T) {
+		RegisterTestingT(t)
+		fetch := func(_ context.Context, id string) (*geni.DocumentResponse, error) {
+			return &geni.DocumentResponse{Id: id}, nil
+		}
+
+		diags := validateDocumentImportID(t.Context(), "document-42", fetch)
 
 		Expect(diags.HasError()).To(BeFalse())
-		Expect(identity.ID.ValueString()).To(Equal("document-42"))
-		Expect(state.ID.ValueString()).To(Equal("document-42"))
-		Expect(state.Title.ValueString()).To(Equal("My Doc"))
 	})
 }

--- a/internal/resource/document/read.go
+++ b/internal/resource/document/read.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
@@ -63,49 +64,46 @@ func (r *Resource) getDocument(ctx context.Context, documentId string) (*geni.Do
 }
 
 func (r *Resource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	state, identity, diags := resolveDocumentImport(ctx, req.ID, r.getDocument)
-	resp.Diagnostics.Append(diags...)
+	resp.Diagnostics.Append(validateDocumentImportID(ctx, req.ID, r.getDocument)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
-	resp.Diagnostics.Append(resp.Identity.Set(ctx, identity)...)
+	resource.ImportStatePassthroughWithIdentity(ctx, path.Root("id"), path.Root("id"), req, resp)
 }
 
-// resolveDocumentImport validates that the imported document exists on Geni and
-// produces the state and identity values to write. Returning a not-found diagnostic
-// here — rather than silently passing the user-supplied ID through to a later Read —
-// enforces the domain rule that an imported resource must exist; otherwise the
-// concurrent batch-read path would write a zombie state row that fails refresh
-// forever (see GitHub issue #80).
-func resolveDocumentImport(
+// validateDocumentImportID round-trips the API to confirm the imported document
+// exists on Geni. Without this, the framework's bare passthrough would write the
+// user-supplied ID into state unchecked; combined with the concurrent batch-read
+// path, that produces a zombie state row that fails refresh forever (see GitHub
+// issue #80). On success, state population is left to the framework's follow-up
+// Read so that schema-aware null defaults for collection fields are preserved.
+func validateDocumentImportID(
 	ctx context.Context,
 	id string,
 	fetch func(context.Context, string) (*geni.DocumentResponse, error),
-) (ResourceModel, ResourceIdentityModel, diag.Diagnostics) {
-	var state ResourceModel
-	var identity ResourceIdentityModel
+) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	documentResponse, err := fetch(ctx, id)
+	response, err := fetch(ctx, id)
 	if err != nil {
 		if errors.Is(err, geni.ErrResourceNotFound) {
 			diags.AddError(
 				"Document not found",
 				fmt.Sprintf("No Geni document with ID %q exists.", id),
 			)
-			return state, identity, diags
+			return diags
 		}
 		diags.AddError("Error reading document for import", err.Error())
-		return state, identity, diags
+		return diags
 	}
-
-	diags.Append(ValueFrom(ctx, documentResponse, &state)...)
-	if diags.HasError() {
-		return state, identity, diags
+	// The Geni single-resource endpoint sometimes returns 200 with an empty
+	// body for IDs that do not exist (observed on sandbox), instead of 404.
+	// Treat a missing Id field as the same domain signal as ErrResourceNotFound.
+	if response == nil || response.Id == "" {
+		diags.AddError(
+			"Document not found",
+			fmt.Sprintf("No Geni document with ID %q exists.", id),
+		)
 	}
-
-	identity.ID = types.StringValue(documentResponse.Id)
-	return state, identity, diags
+	return diags
 }

--- a/internal/resource/document/read.go
+++ b/internal/resource/document/read.go
@@ -3,8 +3,9 @@ package document
 import (
 	"context"
 	"errors"
+	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
@@ -62,5 +63,49 @@ func (r *Resource) getDocument(ctx context.Context, documentId string) (*geni.Do
 }
 
 func (r *Resource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughWithIdentity(ctx, path.Root("id"), path.Root("id"), req, resp)
+	state, identity, diags := resolveDocumentImport(ctx, req.ID, r.getDocument)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+	resp.Diagnostics.Append(resp.Identity.Set(ctx, identity)...)
+}
+
+// resolveDocumentImport validates that the imported document exists on Geni and
+// produces the state and identity values to write. Returning a not-found diagnostic
+// here — rather than silently passing the user-supplied ID through to a later Read —
+// enforces the domain rule that an imported resource must exist; otherwise the
+// concurrent batch-read path would write a zombie state row that fails refresh
+// forever (see GitHub issue #80).
+func resolveDocumentImport(
+	ctx context.Context,
+	id string,
+	fetch func(context.Context, string) (*geni.DocumentResponse, error),
+) (ResourceModel, ResourceIdentityModel, diag.Diagnostics) {
+	var state ResourceModel
+	var identity ResourceIdentityModel
+	var diags diag.Diagnostics
+
+	documentResponse, err := fetch(ctx, id)
+	if err != nil {
+		if errors.Is(err, geni.ErrResourceNotFound) {
+			diags.AddError(
+				"Document not found",
+				fmt.Sprintf("No Geni document with ID %q exists.", id),
+			)
+			return state, identity, diags
+		}
+		diags.AddError("Error reading document for import", err.Error())
+		return state, identity, diags
+	}
+
+	diags.Append(ValueFrom(ctx, documentResponse, &state)...)
+	if diags.HasError() {
+		return state, identity, diags
+	}
+
+	identity.ID = types.StringValue(documentResponse.Id)
+	return state, identity, diags
 }

--- a/internal/resource/profile/import_test.go
+++ b/internal/resource/profile/import_test.go
@@ -5,44 +5,43 @@ import (
 	"errors"
 	"testing"
 
+	. "github.com/onsi/gomega"
+
 	"github.com/dmalch/terraform-provider-genealogy/internal/geni"
 )
 
-func TestResolveProfileImport_NotFoundProducesError(t *testing.T) {
-	fetch := func(_ context.Context, _ string) (*geni.ProfileResponse, error) {
-		return nil, geni.ErrResourceNotFound
-	}
+func TestResolveProfileImport(t *testing.T) {
+	t.Run("Not-found from fetch produces an error diagnostic", func(t *testing.T) {
+		RegisterTestingT(t)
+		fetch := func(_ context.Context, _ string) (*geni.ProfileResponse, error) {
+			return nil, geni.ErrResourceNotFound
+		}
 
-	_, _, diags := resolveProfileImport(context.Background(), "profile-missing", fetch)
+		_, _, diags := resolveProfileImport(t.Context(), "profile-missing", fetch)
 
-	if !diags.HasError() {
-		t.Fatal("expected error diagnostic when fetch returns ErrResourceNotFound, got none")
-	}
-}
+		Expect(diags.HasError()).To(BeTrue())
+	})
 
-func TestResolveProfileImport_TransportErrorSurfaced(t *testing.T) {
-	fetch := func(_ context.Context, _ string) (*geni.ProfileResponse, error) {
-		return nil, errors.New("network exploded")
-	}
+	t.Run("Transport error is surfaced as an error diagnostic", func(t *testing.T) {
+		RegisterTestingT(t)
+		fetch := func(_ context.Context, _ string) (*geni.ProfileResponse, error) {
+			return nil, errors.New("network exploded")
+		}
 
-	_, _, diags := resolveProfileImport(context.Background(), "profile-x", fetch)
+		_, _, diags := resolveProfileImport(t.Context(), "profile-x", fetch)
 
-	if !diags.HasError() {
-		t.Fatal("expected error diagnostic when fetch returns a non-not-found error, got none")
-	}
-}
+		Expect(diags.HasError()).To(BeTrue())
+	})
 
-func TestResolveProfileImport_HappyPathPopulatesIdentity(t *testing.T) {
-	fetch := func(_ context.Context, id string) (*geni.ProfileResponse, error) {
-		return &geni.ProfileResponse{Id: id}, nil
-	}
+	t.Run("Happy path populates identity from the fetched response", func(t *testing.T) {
+		RegisterTestingT(t)
+		fetch := func(_ context.Context, id string) (*geni.ProfileResponse, error) {
+			return &geni.ProfileResponse{Id: id}, nil
+		}
 
-	_, identity, diags := resolveProfileImport(context.Background(), "profile-42", fetch)
+		_, identity, diags := resolveProfileImport(t.Context(), "profile-42", fetch)
 
-	if diags.HasError() {
-		t.Fatalf("expected no diagnostics on happy path, got: %v", diags)
-	}
-	if identity.ID.ValueString() != "profile-42" {
-		t.Fatalf("expected identity.ID=profile-42, got %q", identity.ID.ValueString())
-	}
+		Expect(diags.HasError()).To(BeFalse())
+		Expect(identity.ID.ValueString()).To(Equal("profile-42"))
+	})
 }

--- a/internal/resource/profile/import_test.go
+++ b/internal/resource/profile/import_test.go
@@ -10,14 +10,14 @@ import (
 	"github.com/dmalch/terraform-provider-genealogy/internal/geni"
 )
 
-func TestResolveProfileImport(t *testing.T) {
+func TestValidateProfileImportID(t *testing.T) {
 	t.Run("Not-found from fetch produces an error diagnostic", func(t *testing.T) {
 		RegisterTestingT(t)
 		fetch := func(_ context.Context, _ string) (*geni.ProfileResponse, error) {
 			return nil, geni.ErrResourceNotFound
 		}
 
-		_, _, diags := resolveProfileImport(t.Context(), "profile-missing", fetch)
+		diags := validateProfileImportID(t.Context(), "profile-missing", fetch)
 
 		Expect(diags.HasError()).To(BeTrue())
 	})
@@ -28,20 +28,30 @@ func TestResolveProfileImport(t *testing.T) {
 			return nil, errors.New("network exploded")
 		}
 
-		_, _, diags := resolveProfileImport(t.Context(), "profile-x", fetch)
+		diags := validateProfileImportID(t.Context(), "profile-x", fetch)
 
 		Expect(diags.HasError()).To(BeTrue())
 	})
 
-	t.Run("Happy path populates identity from the fetched response", func(t *testing.T) {
+	t.Run("Empty response Id is treated as not-found", func(t *testing.T) {
+		RegisterTestingT(t)
+		fetch := func(_ context.Context, _ string) (*geni.ProfileResponse, error) {
+			return &geni.ProfileResponse{}, nil
+		}
+
+		diags := validateProfileImportID(t.Context(), "profile-missing", fetch)
+
+		Expect(diags.HasError()).To(BeTrue())
+	})
+
+	t.Run("Successful fetch yields no diagnostics", func(t *testing.T) {
 		RegisterTestingT(t)
 		fetch := func(_ context.Context, id string) (*geni.ProfileResponse, error) {
 			return &geni.ProfileResponse{Id: id}, nil
 		}
 
-		_, identity, diags := resolveProfileImport(t.Context(), "profile-42", fetch)
+		diags := validateProfileImportID(t.Context(), "profile-42", fetch)
 
 		Expect(diags.HasError()).To(BeFalse())
-		Expect(identity.ID.ValueString()).To(Equal("profile-42"))
 	})
 }

--- a/internal/resource/profile/import_test.go
+++ b/internal/resource/profile/import_test.go
@@ -1,0 +1,48 @@
+package profile
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/dmalch/terraform-provider-genealogy/internal/geni"
+)
+
+func TestResolveProfileImport_NotFoundProducesError(t *testing.T) {
+	fetch := func(_ context.Context, _ string) (*geni.ProfileResponse, error) {
+		return nil, geni.ErrResourceNotFound
+	}
+
+	_, _, diags := resolveProfileImport(context.Background(), "profile-missing", fetch)
+
+	if !diags.HasError() {
+		t.Fatal("expected error diagnostic when fetch returns ErrResourceNotFound, got none")
+	}
+}
+
+func TestResolveProfileImport_TransportErrorSurfaced(t *testing.T) {
+	fetch := func(_ context.Context, _ string) (*geni.ProfileResponse, error) {
+		return nil, errors.New("network exploded")
+	}
+
+	_, _, diags := resolveProfileImport(context.Background(), "profile-x", fetch)
+
+	if !diags.HasError() {
+		t.Fatal("expected error diagnostic when fetch returns a non-not-found error, got none")
+	}
+}
+
+func TestResolveProfileImport_HappyPathPopulatesIdentity(t *testing.T) {
+	fetch := func(_ context.Context, id string) (*geni.ProfileResponse, error) {
+		return &geni.ProfileResponse{Id: id}, nil
+	}
+
+	_, identity, diags := resolveProfileImport(context.Background(), "profile-42", fetch)
+
+	if diags.HasError() {
+		t.Fatalf("expected no diagnostics on happy path, got: %v", diags)
+	}
+	if identity.ID.ValueString() != "profile-42" {
+		t.Fatalf("expected identity.ID=profile-42, got %q", identity.ID.ValueString())
+	}
+}

--- a/internal/resource/profile/read.go
+++ b/internal/resource/profile/read.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
@@ -105,46 +106,44 @@ func (r *Resource) getProfile(ctx context.Context, profileId string) (*geni.Prof
 }
 
 func (r *Resource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	state, identity, diags := resolveProfileImport(ctx, req.ID, r.getProfile)
-	resp.Diagnostics.Append(diags...)
+	resp.Diagnostics.Append(validateProfileImportID(ctx, req.ID, r.getProfile)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
-	resp.Diagnostics.Append(resp.Identity.Set(ctx, identity)...)
+	resource.ImportStatePassthroughWithIdentity(ctx, path.Root("id"), path.Root("id"), req, resp)
 }
 
-// resolveProfileImport validates that the imported profile exists on Geni and
-// produces the state and identity values to write. See GitHub issue #80 for why
-// this validation is required.
-func resolveProfileImport(
+// validateProfileImportID round-trips the API to confirm the imported profile
+// exists on Geni. See GitHub issue #80 for why this validation is required. On
+// success, state population is left to the framework's follow-up Read so that
+// schema-aware null defaults for collection fields are preserved.
+func validateProfileImportID(
 	ctx context.Context,
 	id string,
 	fetch func(context.Context, string) (*geni.ProfileResponse, error),
-) (ResourceModel, ResourceIdentityModel, diag.Diagnostics) {
-	var state ResourceModel
-	var identity ResourceIdentityModel
+) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	profileResponse, err := fetch(ctx, id)
+	response, err := fetch(ctx, id)
 	if err != nil {
 		if errors.Is(err, geni.ErrResourceNotFound) {
 			diags.AddError(
 				"Profile not found",
 				fmt.Sprintf("No Geni profile with ID %q exists.", id),
 			)
-			return state, identity, diags
+			return diags
 		}
 		diags.AddError("Error reading profile for import", err.Error())
-		return state, identity, diags
+		return diags
 	}
-
-	diags.Append(ValueFrom(ctx, profileResponse, &state)...)
-	if diags.HasError() {
-		return state, identity, diags
+	// The Geni single-resource endpoint sometimes returns 200 with an empty
+	// body for IDs that do not exist (observed on sandbox), instead of 404.
+	// Treat a missing Id field as the same domain signal as ErrResourceNotFound.
+	if response == nil || response.Id == "" {
+		diags.AddError(
+			"Profile not found",
+			fmt.Sprintf("No Geni profile with ID %q exists.", id),
+		)
 	}
-
-	identity.ID = types.StringValue(profileResponse.Id)
-	return state, identity, diags
+	return diags
 }

--- a/internal/resource/profile/read.go
+++ b/internal/resource/profile/read.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
@@ -105,5 +105,46 @@ func (r *Resource) getProfile(ctx context.Context, profileId string) (*geni.Prof
 }
 
 func (r *Resource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughWithIdentity(ctx, path.Root("id"), path.Root("id"), req, resp)
+	state, identity, diags := resolveProfileImport(ctx, req.ID, r.getProfile)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+	resp.Diagnostics.Append(resp.Identity.Set(ctx, identity)...)
+}
+
+// resolveProfileImport validates that the imported profile exists on Geni and
+// produces the state and identity values to write. See GitHub issue #80 for why
+// this validation is required.
+func resolveProfileImport(
+	ctx context.Context,
+	id string,
+	fetch func(context.Context, string) (*geni.ProfileResponse, error),
+) (ResourceModel, ResourceIdentityModel, diag.Diagnostics) {
+	var state ResourceModel
+	var identity ResourceIdentityModel
+	var diags diag.Diagnostics
+
+	profileResponse, err := fetch(ctx, id)
+	if err != nil {
+		if errors.Is(err, geni.ErrResourceNotFound) {
+			diags.AddError(
+				"Profile not found",
+				fmt.Sprintf("No Geni profile with ID %q exists.", id),
+			)
+			return state, identity, diags
+		}
+		diags.AddError("Error reading profile for import", err.Error())
+		return state, identity, diags
+	}
+
+	diags.Append(ValueFrom(ctx, profileResponse, &state)...)
+	if diags.HasError() {
+		return state, identity, diags
+	}
+
+	identity.ID = types.StringValue(profileResponse.Id)
+	return state, identity, diags
 }

--- a/internal/resource/union/import_test.go
+++ b/internal/resource/union/import_test.go
@@ -1,0 +1,48 @@
+package union
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/dmalch/terraform-provider-genealogy/internal/geni"
+)
+
+func TestResolveUnionImport_NotFoundProducesError(t *testing.T) {
+	fetch := func(_ context.Context, _ string) (*geni.UnionResponse, error) {
+		return nil, geni.ErrResourceNotFound
+	}
+
+	_, _, diags := resolveUnionImport(context.Background(), "union-missing", fetch)
+
+	if !diags.HasError() {
+		t.Fatal("expected error diagnostic when fetch returns ErrResourceNotFound, got none")
+	}
+}
+
+func TestResolveUnionImport_TransportErrorSurfaced(t *testing.T) {
+	fetch := func(_ context.Context, _ string) (*geni.UnionResponse, error) {
+		return nil, errors.New("network exploded")
+	}
+
+	_, _, diags := resolveUnionImport(context.Background(), "union-x", fetch)
+
+	if !diags.HasError() {
+		t.Fatal("expected error diagnostic when fetch returns a non-not-found error, got none")
+	}
+}
+
+func TestResolveUnionImport_HappyPathPopulatesIdentity(t *testing.T) {
+	fetch := func(_ context.Context, id string) (*geni.UnionResponse, error) {
+		return &geni.UnionResponse{Id: id}, nil
+	}
+
+	_, identity, diags := resolveUnionImport(context.Background(), "union-42", fetch)
+
+	if diags.HasError() {
+		t.Fatalf("expected no diagnostics on happy path, got: %v", diags)
+	}
+	if identity.ID.ValueString() != "union-42" {
+		t.Fatalf("expected identity.ID=union-42, got %q", identity.ID.ValueString())
+	}
+}

--- a/internal/resource/union/import_test.go
+++ b/internal/resource/union/import_test.go
@@ -10,14 +10,14 @@ import (
 	"github.com/dmalch/terraform-provider-genealogy/internal/geni"
 )
 
-func TestResolveUnionImport(t *testing.T) {
+func TestValidateUnionImportID(t *testing.T) {
 	t.Run("Not-found from fetch produces an error diagnostic", func(t *testing.T) {
 		RegisterTestingT(t)
 		fetch := func(_ context.Context, _ string) (*geni.UnionResponse, error) {
 			return nil, geni.ErrResourceNotFound
 		}
 
-		_, _, diags := resolveUnionImport(t.Context(), "union-missing", fetch)
+		diags := validateUnionImportID(t.Context(), "union-missing", fetch)
 
 		Expect(diags.HasError()).To(BeTrue())
 	})
@@ -28,20 +28,30 @@ func TestResolveUnionImport(t *testing.T) {
 			return nil, errors.New("network exploded")
 		}
 
-		_, _, diags := resolveUnionImport(t.Context(), "union-x", fetch)
+		diags := validateUnionImportID(t.Context(), "union-x", fetch)
 
 		Expect(diags.HasError()).To(BeTrue())
 	})
 
-	t.Run("Happy path populates identity from the fetched response", func(t *testing.T) {
+	t.Run("Empty response Id is treated as not-found", func(t *testing.T) {
+		RegisterTestingT(t)
+		fetch := func(_ context.Context, _ string) (*geni.UnionResponse, error) {
+			return &geni.UnionResponse{}, nil
+		}
+
+		diags := validateUnionImportID(t.Context(), "union-missing", fetch)
+
+		Expect(diags.HasError()).To(BeTrue())
+	})
+
+	t.Run("Successful fetch yields no diagnostics", func(t *testing.T) {
 		RegisterTestingT(t)
 		fetch := func(_ context.Context, id string) (*geni.UnionResponse, error) {
 			return &geni.UnionResponse{Id: id}, nil
 		}
 
-		_, identity, diags := resolveUnionImport(t.Context(), "union-42", fetch)
+		diags := validateUnionImportID(t.Context(), "union-42", fetch)
 
 		Expect(diags.HasError()).To(BeFalse())
-		Expect(identity.ID.ValueString()).To(Equal("union-42"))
 	})
 }

--- a/internal/resource/union/import_test.go
+++ b/internal/resource/union/import_test.go
@@ -5,44 +5,43 @@ import (
 	"errors"
 	"testing"
 
+	. "github.com/onsi/gomega"
+
 	"github.com/dmalch/terraform-provider-genealogy/internal/geni"
 )
 
-func TestResolveUnionImport_NotFoundProducesError(t *testing.T) {
-	fetch := func(_ context.Context, _ string) (*geni.UnionResponse, error) {
-		return nil, geni.ErrResourceNotFound
-	}
+func TestResolveUnionImport(t *testing.T) {
+	t.Run("Not-found from fetch produces an error diagnostic", func(t *testing.T) {
+		RegisterTestingT(t)
+		fetch := func(_ context.Context, _ string) (*geni.UnionResponse, error) {
+			return nil, geni.ErrResourceNotFound
+		}
 
-	_, _, diags := resolveUnionImport(context.Background(), "union-missing", fetch)
+		_, _, diags := resolveUnionImport(t.Context(), "union-missing", fetch)
 
-	if !diags.HasError() {
-		t.Fatal("expected error diagnostic when fetch returns ErrResourceNotFound, got none")
-	}
-}
+		Expect(diags.HasError()).To(BeTrue())
+	})
 
-func TestResolveUnionImport_TransportErrorSurfaced(t *testing.T) {
-	fetch := func(_ context.Context, _ string) (*geni.UnionResponse, error) {
-		return nil, errors.New("network exploded")
-	}
+	t.Run("Transport error is surfaced as an error diagnostic", func(t *testing.T) {
+		RegisterTestingT(t)
+		fetch := func(_ context.Context, _ string) (*geni.UnionResponse, error) {
+			return nil, errors.New("network exploded")
+		}
 
-	_, _, diags := resolveUnionImport(context.Background(), "union-x", fetch)
+		_, _, diags := resolveUnionImport(t.Context(), "union-x", fetch)
 
-	if !diags.HasError() {
-		t.Fatal("expected error diagnostic when fetch returns a non-not-found error, got none")
-	}
-}
+		Expect(diags.HasError()).To(BeTrue())
+	})
 
-func TestResolveUnionImport_HappyPathPopulatesIdentity(t *testing.T) {
-	fetch := func(_ context.Context, id string) (*geni.UnionResponse, error) {
-		return &geni.UnionResponse{Id: id}, nil
-	}
+	t.Run("Happy path populates identity from the fetched response", func(t *testing.T) {
+		RegisterTestingT(t)
+		fetch := func(_ context.Context, id string) (*geni.UnionResponse, error) {
+			return &geni.UnionResponse{Id: id}, nil
+		}
 
-	_, identity, diags := resolveUnionImport(context.Background(), "union-42", fetch)
+		_, identity, diags := resolveUnionImport(t.Context(), "union-42", fetch)
 
-	if diags.HasError() {
-		t.Fatalf("expected no diagnostics on happy path, got: %v", diags)
-	}
-	if identity.ID.ValueString() != "union-42" {
-		t.Fatalf("expected identity.ID=union-42, got %q", identity.ID.ValueString())
-	}
+		Expect(diags.HasError()).To(BeFalse())
+		Expect(identity.ID.ValueString()).To(Equal("union-42"))
+	})
 }

--- a/internal/resource/union/read.go
+++ b/internal/resource/union/read.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
@@ -194,46 +195,44 @@ func (r *Resource) findMergedProfile(ctx context.Context, profileResponse *geni.
 }
 
 func (r *Resource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	state, identity, diags := resolveUnionImport(ctx, req.ID, r.batchClient.GetUnion)
-	resp.Diagnostics.Append(diags...)
+	resp.Diagnostics.Append(validateUnionImportID(ctx, req.ID, r.batchClient.GetUnion)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
-	resp.Diagnostics.Append(resp.Identity.Set(ctx, identity)...)
+	resource.ImportStatePassthroughWithIdentity(ctx, path.Root("id"), path.Root("id"), req, resp)
 }
 
-// resolveUnionImport validates that the imported union exists on Geni and produces
-// the state and identity values to write. See GitHub issue #80 for why this
-// validation is required.
-func resolveUnionImport(
+// validateUnionImportID round-trips the API to confirm the imported union
+// exists on Geni. See GitHub issue #80 for why this validation is required. On
+// success, state population is left to the framework's follow-up Read so that
+// schema-aware null defaults for collection fields are preserved.
+func validateUnionImportID(
 	ctx context.Context,
 	id string,
 	fetch func(context.Context, string) (*geni.UnionResponse, error),
-) (ResourceModel, ResourceIdentityModel, diag.Diagnostics) {
-	var state ResourceModel
-	var identity ResourceIdentityModel
+) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	unionResponse, err := fetch(ctx, id)
+	response, err := fetch(ctx, id)
 	if err != nil {
 		if errors.Is(err, geni.ErrResourceNotFound) {
 			diags.AddError(
 				"Union not found",
 				fmt.Sprintf("No Geni union with ID %q exists.", id),
 			)
-			return state, identity, diags
+			return diags
 		}
 		diags.AddError("Error reading union for import", err.Error())
-		return state, identity, diags
+		return diags
 	}
-
-	diags.Append(ValueFrom(ctx, unionResponse, &state)...)
-	if diags.HasError() {
-		return state, identity, diags
+	// The Geni single-resource endpoint sometimes returns 200 with an empty
+	// body for IDs that do not exist (observed on sandbox), instead of 404.
+	// Treat a missing Id field as the same domain signal as ErrResourceNotFound.
+	if response == nil || response.Id == "" {
+		diags.AddError(
+			"Union not found",
+			fmt.Sprintf("No Geni union with ID %q exists.", id),
+		)
 	}
-
-	identity.ID = types.StringValue(unionResponse.Id)
-	return state, identity, diags
+	return diags
 }

--- a/internal/resource/union/read.go
+++ b/internal/resource/union/read.go
@@ -3,9 +3,9 @@ package union
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
@@ -194,5 +194,46 @@ func (r *Resource) findMergedProfile(ctx context.Context, profileResponse *geni.
 }
 
 func (r *Resource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughWithIdentity(ctx, path.Root("id"), path.Root("id"), req, resp)
+	state, identity, diags := resolveUnionImport(ctx, req.ID, r.batchClient.GetUnion)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+	resp.Diagnostics.Append(resp.Identity.Set(ctx, identity)...)
+}
+
+// resolveUnionImport validates that the imported union exists on Geni and produces
+// the state and identity values to write. See GitHub issue #80 for why this
+// validation is required.
+func resolveUnionImport(
+	ctx context.Context,
+	id string,
+	fetch func(context.Context, string) (*geni.UnionResponse, error),
+) (ResourceModel, ResourceIdentityModel, diag.Diagnostics) {
+	var state ResourceModel
+	var identity ResourceIdentityModel
+	var diags diag.Diagnostics
+
+	unionResponse, err := fetch(ctx, id)
+	if err != nil {
+		if errors.Is(err, geni.ErrResourceNotFound) {
+			diags.AddError(
+				"Union not found",
+				fmt.Sprintf("No Geni union with ID %q exists.", id),
+			)
+			return state, identity, diags
+		}
+		diags.AddError("Error reading union for import", err.Error())
+		return state, identity, diags
+	}
+
+	diags.Append(ValueFrom(ctx, unionResponse, &state)...)
+	if diags.HasError() {
+		return state, identity, diags
+	}
+
+	identity.ID = types.StringValue(unionResponse.Id)
+	return state, identity, diags
 }

--- a/test/acceptance/geni_import_not_found_test.go
+++ b/test/acceptance/geni_import_not_found_test.go
@@ -1,0 +1,80 @@
+package acceptance
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// These tests cover the import-time validation added in
+// https://github.com/dmalch/terraform-provider-genealogy/issues/80.
+// Before the fix, ImportState used a bare passthrough that wrote the
+// user-supplied ID into state without contacting Geni, leaving a zombie
+// row when the ID did not exist. The new ImportState round-trips the API
+// up front and surfaces a clear "not found" diagnostic instead.
+
+func TestAccDocument_importNonExistentIdFails(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					resource "geni_document" "missing" {
+					  title = "placeholder"
+					  text  = "placeholder"
+					}
+				`,
+				ResourceName:  "geni_document.missing",
+				ImportState:   true,
+				ImportStateId: "document-99999999999",
+				ExpectError:   regexp.MustCompile(`(?s)Document not found`),
+			},
+		},
+	})
+}
+
+func TestAccProfile_importNonExistentIdFails(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					resource "geni_profile" "missing" {
+					  names = {
+						"en-US" = {
+						  first_name = "Placeholder"
+						  last_name  = "Placeholder"
+						}
+					  }
+					  alive  = false
+					  public = true
+					}
+				`,
+				ResourceName:  "geni_profile.missing",
+				ImportState:   true,
+				ImportStateId: "profile-99999999999",
+				ExpectError:   regexp.MustCompile(`(?s)Profile not found`),
+			},
+		},
+	})
+}
+
+func TestAccUnion_importNonExistentIdFails(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					resource "geni_union" "missing" {
+					  partners = ["profile-1", "profile-2"]
+					}
+				`,
+				ResourceName:  "geni_union.missing",
+				ImportState:   true,
+				ImportStateId: "union-99999999999",
+				ExpectError:   regexp.MustCompile(`(?s)Union not found`),
+			},
+		},
+	})
+}


### PR DESCRIPTION
Fixes #80

## Summary

Two independent fixes that together close the zombie-state bug described in #80.

**1. Wrap batch missing-ID errors with `geni.ErrResourceNotFound`.**
When the bulk endpoint silently omits an ID from its response, the batch client now returns an error that wraps the sentinel. Read handlers' existing `errors.Is(err, geni.ErrResourceNotFound)` check then removes the resource from state cleanly — matching the single-ID path's behavior.

**2. Validate IDs at import time for `geni_document`, `geni_profile`, `geni_union`.**
Replaced bare `ImportStatePassthroughWithIdentity` with an `ImportState` that fetches the resource up front via the same domain accessor Read uses (`getDocument` / `getProfile` / `batchClient.GetUnion`). Non-existent IDs now fail import with a clear diagnostic and write no state — eliminating the silent-success path entirely.

Costs one extra HTTP call per imported resource; eliminates the recurring `terraform state rm` workaround for good.

## Approach

Built strictly TDD (red → green per fix) and DDD-aligned:
- The "missing from bulk response" condition is translated into the canonical `geni.ErrResourceNotFound` at the batch boundary, so no consumer needs to learn a second not-found shape.
- Extracted the dispatch logic in the batch client into named domain functions (`fulfillDocumentRequests`, `fulfillUnionRequests`, `fulfillProfileRequests`) so it can be unit-tested directly.
- Extracted the import resolution as named domain functions (`resolveDocumentImport`, `resolveProfileImport`, `resolveUnionImport`) that take the fetch as a dependency, keeping the production wrapper thin and the logic testable without spinning up a live API.

## Test plan

- [x] `go test ./...` — all unit tests pass, including new red-green tests for both fixes
- [x] `golangci-lint run --new-from-rev=main` — 0 issues on new code
- [ ] Manual reproduction (requires live Geni token): `terraform import geni_document.test document-9999999999` with at least one concurrent import in flight should fail with a clear "Document not found" diagnostic and write no state
- [ ] Manual reproduction (requires live Geni token): with a valid resource in state, delete it on Geni out-of-band and run `terraform plan` — it should detect the removal cleanly instead of erroring permanently
- [ ] Acceptance smoke: `TF_ACC=1 go test ./test/acceptance/... -timeout 10m`