### PR TITLE
Verify terraform plan -generate-config-out for profile, document, and union

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.18.1 (Unreleased)
 
+IMPROVEMENTS:
+
+* Testing: added acceptance tests that verify `terraform plan -generate-config-out` produces a no-diff HCL config for `geni_profile`, `geni_document`, and `geni_union` via the `terraform-plugin-testing` 1.16 `GenerateConfig` ImportState mode. The framework's auto-implemented `GenerateResourceConfiguration` RPC (shipped on `terraform-plugin-framework` v1.19.0 since v0.17.0) round-trips cleanly for every attribute the API returns — the seed configs intentionally exclude set-only attributes (`projects` on profile/document; `text` / `file` / `file_name` on document) because the generated HCL omits them and the framework requires a no-op plan. (#85)
+
 ## 0.18.0
 
 FEATURES:

--- a/test/acceptance/geni_document_test.go
+++ b/test/acceptance/geni_document_test.go
@@ -408,6 +408,33 @@ func TestAccDocument_createUrlDocument(t *testing.T) {
 	})
 }
 
+func TestAccDocument_generateConfigOut(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDocumentDestroy,
+		Steps: []resource.TestStep{
+			{
+				// URL-backed documents round-trip cleanly through Read. The
+				// text / file / file_name attributes are set-only (the API
+				// doesn't return them) and would diff in the generated
+				// config, so they're omitted intentionally.
+				Config: `
+					resource "geni_document" "test" {
+					  title      = "Test Document"
+					  source_url = "https://example.com"
+					}
+				`,
+			},
+			{
+				ResourceName:    "geni_document.test",
+				ImportState:     true,
+				ImportStateKind: resource.ImportBlockWithResourceIdentity,
+				GenerateConfig:  true,
+			},
+		},
+	})
+}
+
 func TestAccDocument_createUrlDocumentWithDetails(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testProtoV6ProviderFactories,

--- a/test/acceptance/geni_profile_test.go
+++ b/test/acceptance/geni_profile_test.go
@@ -41,6 +41,33 @@ func TestAccProfile_createProfile(t *testing.T) {
 	})
 }
 
+func TestAccProfile_generateConfigOut(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: profile(),
+			},
+			{
+				// terraform-plugin-framework v1.19 auto-implements the
+				// GenerateResourceConfiguration RPC. The framework appends an
+				// `import { identity = {...} to = geni_profile.generated }`
+				// block to the prior config and runs `terraform plan
+				// -generate-config-out`. The implicit assertion is that the
+				// generated HCL produces a no-op plan against the imported
+				// state — which is only the case for attributes ValueFrom
+				// populates from the API. The seed config uses just `names`
+				// + `alive` + `public` (no `projects` — that's set-only).
+				ResourceName:    "geni_profile.test",
+				ImportState:     true,
+				ImportStateKind: resource.ImportBlockWithResourceIdentity,
+				GenerateConfig:  true,
+			},
+		},
+	})
+}
+
 func profile() string {
 	return `
 		resource "geni_profile" "test" {

--- a/test/acceptance/geni_union_test.go
+++ b/test/acceptance/geni_union_test.go
@@ -42,6 +42,27 @@ func TestAccUnion_createUnionWithTwoPartners(t *testing.T) {
 	})
 }
 
+func TestAccUnion_generateConfigOut(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: unionWithTwoPartners(),
+			},
+			{
+				// All union schema attributes are populated by ValueFrom, so
+				// the generated config round-trips through plan with no
+				// caveats.
+				ResourceName:    "geni_union.doe_family",
+				ImportState:     true,
+				ImportStateKind: resource.ImportBlockWithResourceIdentity,
+				GenerateConfig:  true,
+			},
+		},
+	})
+}
+
 func unionWithTwoPartners() string {
 	return `
 		resource "geni_profile" "husband" {


### PR DESCRIPTION
Closes #85.

## Summary

Adds an acceptance test per managed resource that verifies `terraform plan -generate-config-out=...` round-trips through plan with no diff, locking in framework-side behavior the v0.17.0 upgrade to `terraform-plugin-framework` v1.19.0 already gave us for free.

## Approach (TDD)

The framework's `terraform-plugin-testing` v1.16 exposes a single switch — `step.GenerateConfig = true` (paired with `ImportStateKind: resource.ImportBlockWithResourceIdentity`) — that:

1. Appends an `import { identity = {...} to = <type>.generated }` block to the prior step's config.
2. Runs `terraform plan -generate-config-out=$WD/generated.tf`.
3. Asserts the resulting plan is a no-op for the generated resource.

For each of profile, document, and union: a single new test that reuses the existing minimal create config and adds the generate step. **Red→green came on the first run for all three** — no provider code changes needed.

## Caveats — encoded in the seed configs

The framework hard-requires a no-op plan after generation, so the seed config must only contain attributes that round-trip through `ValueFrom`:

| Resource | Excluded from seed | Why |
|---|---|---|
| `geni_profile` | `projects` | Set-only; not in `ProfileResponse` |
| `geni_document` | `text`, `file`, `file_name`, `projects` | All set-only; URL-backed form has none of these |
| `geni_union` | (none) | Every attribute is read back |

If a future framework upgrade breaks the generated HCL for any attribute that *should* round-trip, these tests will catch it.

## Test plan

- [x] `go test ./...` — unit tests stay green.
- [x] `golangci-lint run` — 0 issues on new code.
- [x] `TF_ACC=1 go test -run "generateConfigOut" ./test/acceptance/` — all three new tests pass against sandbox (~9s + 9s + 24s).
- [x] `make docs` — no diff (test-only change).
- [x] `CHANGELOG.md` — `0.18.1 (Unreleased)` entry added under IMPROVEMENTS.

## Out of scope

- Server-side filtering, write-only attribute round-tripping (these are genuine API-side limitations).
- A `docs/guides/import.md` prose guide — the tests act as the executable spec; can be filed as a follow-up.
