### PR TITLE
Fix geni_profile Read omitting projects (#89)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.18.1 (Unreleased)
 
+BUG FIXES:
+
+* Profile: `terraform import`, batched managed-resource Read, and the v0.18.0 `geni_profile` list resource now request `project_ids` from the Geni API and copy it into the `projects` attribute. Previously the field was omitted from the shared `fields=` query parameter, so state landed with `projects = null` and every subsequent `terraform plan` against an HCL `projects = [...]` showed a spurious in-place update — in large workspaces this masked real drift behind thousands of no-op changes. (#89)
+
 IMPROVEMENTS:
 
 * Testing: added acceptance tests that verify `terraform plan -generate-config-out` produces a no-diff HCL config for `geni_profile`, `geni_document`, and `geni_union` via the `terraform-plugin-testing` 1.16 `GenerateConfig` ImportState mode. The framework's auto-implemented `GenerateResourceConfiguration` RPC (shipped on `terraform-plugin-framework` v1.19.0 since v0.17.0) round-trips cleanly for every attribute the API returns — the seed configs intentionally exclude set-only attributes (`projects` on profile/document; `text` / `file` / `file_name` on document) because the generated HCL omits them and the framework requires a no-op plan. (#85)

--- a/internal/geni/profile.go
+++ b/internal/geni/profile.go
@@ -129,6 +129,8 @@ type ProfileResponse struct {
 	Url string `json:"url,omitempty"`
 	// Unions is the URLs to unions
 	Unions []string `json:"unions,omitempty"`
+	// Projects are the IDs of projects this profile is a member of
+	Projects []string `json:"project_ids,omitempty"`
 	// Deleted is a boolean that indicates whether the profile is deleted
 	Deleted bool `json:"deleted"`
 	// UpdatedAt is the timestamp of when the profile was last updated
@@ -355,7 +357,7 @@ func (c *Client) GetProfile(ctx context.Context, profileId string) (*ProfileResp
 
 func (c *Client) addProfileFieldsQueryParams(req *http.Request) {
 	query := req.URL.Query()
-	query.Add("fields", "id,first_name,last_name,middle_name,maiden_name,display_name,nicknames,names,gender,birth,baptism,death,burial,cause_of_death,current_residence,about_me,detail_strings,unions,is_alive,public,deleted,merged_into,updated_at,created_at")
+	query.Add("fields", "id,first_name,last_name,middle_name,maiden_name,display_name,nicknames,names,gender,birth,baptism,death,burial,cause_of_death,current_residence,about_me,detail_strings,unions,project_ids,is_alive,public,deleted,merged_into,updated_at,created_at")
 	req.URL.RawQuery = query.Encode()
 }
 

--- a/internal/geni/profile_helpers_test.go
+++ b/internal/geni/profile_helpers_test.go
@@ -1,11 +1,28 @@
 package geni
 
 import (
+	"net/http"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/gomega"
 	"golang.org/x/oauth2"
 )
+
+func TestAddProfileFieldsQueryParams(t *testing.T) {
+	t.Run("requests project_ids so import and bulk Read populate profile.projects in state", func(t *testing.T) {
+		RegisterTestingT(t)
+		client := NewClient(oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test"}), false)
+
+		req, err := http.NewRequest(http.MethodGet, "https://www.geni.com/api/profile-1", nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		client.addProfileFieldsQueryParams(req)
+
+		fields := req.URL.Query().Get("fields")
+		Expect(strings.Split(fields, ",")).To(ContainElement("project_ids"))
+	})
+}
 
 func TestFixResponse(t *testing.T) {
 	t.Run("Strips production API URL prefix from union URLs", func(t *testing.T) {

--- a/internal/resource/profile/convert.go
+++ b/internal/resource/profile/convert.go
@@ -43,6 +43,10 @@ func ValueFrom(ctx context.Context, profile *geni.ProfileResponse, profileModel 
 	d.Append(diags...)
 	profileModel.Unions = unions
 
+	projects, diags := types.SetValueFrom(ctx, types.StringType, profile.Projects)
+	d.Append(diags...)
+	profileModel.Projects = projects
+
 	birth, diags := event.ValueFrom(ctx, profile.Birth)
 	d.Append(diags...)
 	profileModel.Birth = birth
@@ -256,6 +260,10 @@ func UpdateComputedFields(ctx context.Context, profile *geni.ProfileResponse, pr
 	unions, diags := types.SetValueFrom(ctx, types.StringType, profile.Unions)
 	d.Append(diags...)
 	profileModel.Unions = unions
+
+	projects, diags := types.SetValueFrom(ctx, types.StringType, profile.Projects)
+	d.Append(diags...)
+	profileModel.Projects = projects
 
 	birth, diags := event.UpdateComputedFieldsInEvent(ctx, profileModel.Birth, profile.Birth)
 	d.Append(diags...)

--- a/internal/resource/profile/convert.go
+++ b/internal/resource/profile/convert.go
@@ -261,9 +261,11 @@ func UpdateComputedFields(ctx context.Context, profile *geni.ProfileResponse, pr
 	d.Append(diags...)
 	profileModel.Unions = unions
 
-	projects, diags := types.SetValueFrom(ctx, types.StringType, profile.Projects)
-	d.Append(diags...)
-	profileModel.Projects = projects
+	// Projects is intentionally not updated here: Create/Update pass the
+	// pre-link API response (the AddProfileToProject calls fire afterwards),
+	// so profile.Projects is stale and would overwrite plan.Projects with
+	// null. The Read path's ValueFrom is responsible for populating
+	// projects from the API; the plan is authoritative on Create/Update.
 
 	birth, diags := event.UpdateComputedFieldsInEvent(ctx, profileModel.Birth, profile.Birth)
 	d.Append(diags...)

--- a/internal/resource/profile/convert_test.go
+++ b/internal/resource/profile/convert_test.go
@@ -36,7 +36,8 @@ func TestValueFrom(t *testing.T) {
 					LastName:   ptr("Doe"),
 				},
 			},
-			Unions: []string{"union1", "union2"},
+			Unions:   []string{"union1", "union2"},
+			Projects: []string{"project-4505748", "project-4497781"},
 			Birth: &geni.EventElement{
 				Date: &geni.DateElement{
 					Day:   ptr[int32](1),
@@ -90,6 +91,20 @@ func TestValueFrom(t *testing.T) {
 			Nicknames:     types.SetNull(types.StringType),
 		}))
 		Expect(actualValue.CreatedAt.ValueString()).To(Equal(givenProfile.CreatedAt))
+
+		var actualProjects []string
+		Expect(actualValue.Projects.ElementsAs(t.Context(), &actualProjects, false).HasError()).To(BeFalse())
+		Expect(actualProjects).To(ConsistOf("project-4505748", "project-4497781"))
+	})
+
+	t.Run("when the response has no project memberships, Projects is a typed null Set[String]", func(t *testing.T) {
+		RegisterTestingT(t)
+		given := &geni.ProfileResponse{Id: "profile-1"}
+		actual := &ResourceModel{}
+
+		Expect(ValueFrom(t.Context(), given, actual).HasError()).To(BeFalse())
+		Expect(actual.Projects.IsNull()).To(BeTrue())
+		Expect(actual.Projects.ElementType(t.Context())).To(Equal(types.StringType))
 	})
 
 	t.Run("when about me in multiple languages is defiled", func(t *testing.T) {
@@ -206,8 +221,9 @@ func TestUpdateComputedFields(t *testing.T) {
 	t.Run("Updates ID, unions, events, about, deleted, merged_into, and created_at", func(t *testing.T) {
 		RegisterTestingT(t)
 		givenProfile := &geni.ProfileResponse{
-			Id:     "profile-123",
-			Unions: []string{"union-1", "union-2"},
+			Id:       "profile-123",
+			Unions:   []string{"union-1", "union-2"},
+			Projects: []string{"project-4505748"},
 			Birth: &geni.EventElement{
 				Name: "Birth",
 				Date: &geni.DateElement{Year: ptr[int32](1990)},
@@ -234,6 +250,9 @@ func TestUpdateComputedFields(t *testing.T) {
 		Expect(diags.HasError()).To(BeFalse())
 		Expect(model.ID.ValueString()).To(Equal("profile-123"))
 		Expect(model.Unions.Elements()).To(HaveLen(2))
+		var actualProjects []string
+		Expect(model.Projects.ElementsAs(t.Context(), &actualProjects, false).HasError()).To(BeFalse())
+		Expect(actualProjects).To(ConsistOf("project-4505748"))
 		Expect(model.Deleted.ValueBool()).To(BeTrue())
 		Expect(model.MergedInto.ValueString()).To(Equal("profile-456"))
 		Expect(model.CreatedAt.ValueString()).To(Equal("1719709400"))

--- a/internal/resource/profile/convert_test.go
+++ b/internal/resource/profile/convert_test.go
@@ -221,9 +221,11 @@ func TestUpdateComputedFields(t *testing.T) {
 	t.Run("Updates ID, unions, events, about, deleted, merged_into, and created_at", func(t *testing.T) {
 		RegisterTestingT(t)
 		givenProfile := &geni.ProfileResponse{
-			Id:       "profile-123",
-			Unions:   []string{"union-1", "union-2"},
-			Projects: []string{"project-4505748"},
+			Id:     "profile-123",
+			Unions: []string{"union-1", "union-2"},
+			// Projects intentionally omitted: Create/Update pass the pre-link
+			// API response, so it is stale and must not overwrite plan.Projects.
+			Projects: []string{"project-stale"},
 			Birth: &geni.EventElement{
 				Name: "Birth",
 				Date: &geni.DateElement{Year: ptr[int32](1990)},
@@ -236,6 +238,9 @@ func TestUpdateComputedFields(t *testing.T) {
 			CreatedAt:  "1719709400",
 		}
 
+		planProjects, planProjectsDiags := types.SetValueFrom(t.Context(), types.StringType, []string{"project-from-plan"})
+		Expect(planProjectsDiags.HasError()).To(BeFalse())
+
 		model := &ResourceModel{
 			Birth:            types.ObjectNull(event.EventModelAttributeTypes()),
 			Baptism:          types.ObjectNull(event.EventModelAttributeTypes()),
@@ -243,6 +248,7 @@ func TestUpdateComputedFields(t *testing.T) {
 			Burial:           types.ObjectNull(event.EventModelAttributeTypes()),
 			CurrentResidence: types.ObjectNull(event.LocationModelAttributeTypes()),
 			About:            types.MapNull(types.StringType),
+			Projects:         planProjects,
 		}
 
 		diags := UpdateComputedFields(t.Context(), givenProfile, model)
@@ -250,9 +256,12 @@ func TestUpdateComputedFields(t *testing.T) {
 		Expect(diags.HasError()).To(BeFalse())
 		Expect(model.ID.ValueString()).To(Equal("profile-123"))
 		Expect(model.Unions.Elements()).To(HaveLen(2))
+		// Projects in the plan must survive: the API response passed to
+		// UpdateComputedFields is captured before AddProfileToProject runs,
+		// so its Projects field is stale and must not overwrite the plan.
 		var actualProjects []string
 		Expect(model.Projects.ElementsAs(t.Context(), &actualProjects, false).HasError()).To(BeFalse())
-		Expect(actualProjects).To(ConsistOf("project-4505748"))
+		Expect(actualProjects).To(ConsistOf("project-from-plan"))
 		Expect(model.Deleted.ValueBool()).To(BeTrue())
 		Expect(model.MergedInto.ValueString()).To(Equal("profile-456"))
 		Expect(model.CreatedAt.ValueString()).To(Equal("1719709400"))

--- a/test/acceptance/geni_project_test.go
+++ b/test/acceptance/geni_project_test.go
@@ -1,11 +1,13 @@
 package acceptance
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
@@ -90,6 +92,51 @@ func TestAccProject_addProfileToTwoProject(t *testing.T) {
 						knownvalue.StringExact("project-8"),
 						knownvalue.StringExact("project-9"),
 					})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccProject_importProfilePopulatesProjects(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					data "geni_project" "test" {
+					  id = "project-8"
+					}
+
+					resource "geni_profile" "test" {
+					  names = {
+						"en-US" = {
+							first_name = "John"
+							last_name = "Doe"
+						}
+					  }
+					  alive = false
+					  public = true
+					  projects = [data.geni_project.test.id]
+					}
+					`,
+			},
+			{
+				ResourceName:    "geni_profile.test",
+				ImportState:     true,
+				ImportStateKind: resource.ImportBlockWithResourceIdentity,
+				ImportStateCheck: func(states []*terraform.InstanceState) error {
+					if len(states) != 1 {
+						return fmt.Errorf("expected 1 imported state, got %d", len(states))
+					}
+					attrs := states[0].Attributes
+					if attrs["projects.#"] != "1" {
+						return fmt.Errorf("expected projects.# = 1, got %q", attrs["projects.#"])
+					}
+					if attrs["projects.0"] != "project-8" {
+						return fmt.Errorf("expected projects.0 = project-8, got %q", attrs["projects.0"])
+					}
+					return nil
 				},
 			},
 		},


### PR DESCRIPTION
## Summary

- Fixes #89: `terraform import`, batched Read, and the v0.18.0 `geni_profile` list resource now request `project_ids` from the Geni API and copy it into the `projects` attribute. Previously the field was omitted from the shared `fields=` query parameter, so state landed with `projects = null` and every subsequent plan against an HCL `projects = [...]` surfaced a spurious in-place `update` (5,149 / 5,149 affected resources in the reporter's workspace).
- Verified live: the wire field is `project_ids` (the issue's suggested `projects` is silently ignored). The Go field name stays `Projects` with `json:"project_ids,omitempty"`, mirroring how `Unions []string` already pairs a domain name with the wire encoding. Terraform schema is unchanged.

## Out of scope

The original #89 also flagged secondary `birth.name` / `death.name` drift. That turned out to be broader than the `name` sub-attribute — the Geni API auto-creates the whole `death` event object whenever `cause_of_death` is set, and state then carries the parent object that config has null. Split out as #91 (reproduced on `main`, not introduced by this PR — see Test plan).

## Test plan

- [x] `go test ./internal/resource/profile/ -run TestValueFrom` — happy-path covers `Projects` round-trip; new sub-test guards against typed-null regression to `DynamicPseudoType`.
- [x] `go test ./internal/resource/profile/ -run TestUpdateComputedFields` — asserts the API response's stale `Projects` does NOT overwrite plan (fix for the inconsistent-result-after-apply surfaced by the new acc test).
- [x] `go test ./internal/geni/ -run TestAddProfileFieldsQueryParams` — `fields=` CSV contains `project_ids`.
- [x] `go test ./...` — full unit suite green.
- [x] `golangci-lint run` — 0 issues.
- [x] `make docs` — no diff (schema unchanged).
- [x] `TF_ACC=1 go test ./test/acceptance/` — full sandbox suite, 56 / 57 pass. The one failure (`TestAccProfile_removeProfileDeathDetails`) reproduces identically on `main` and is tracked in #91; it is unrelated to this change.
- [x] End-to-end import: new `TestAccProject_importProfilePopulatesProjects` against the Geni sandbox attaches a profile to `project-8`, imports via `ImportBlockWithResourceIdentity`, and asserts `projects = ["project-8"]` is populated in the post-import state.