### PR TITLE
Fix profile refresh-plan flap on auto-created events (#91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.18.2 (Unreleased)
 
+BUG FIXES:
+
+* Profile: events (`birth`, `death`, `baptism`, `burial`) that the Geni API auto-creates from a sibling input — most visibly `death` when `cause_of_death` is set — no longer flap the refresh plan. The Read path now treats an event that carries only a server-generated name (no `date` and no `location`) as no event, so `state.death` stays null when the user did not author a `death` block in HCL. User-set events still round-trip because the schema validator already requires them to carry `date` or `location`. (#91)
+
 ## 0.18.1
 
 BUG FIXES:

--- a/internal/resource/event/convert.go
+++ b/internal/resource/event/convert.go
@@ -135,27 +135,36 @@ func DateRangeObjectValueFrom(ctx context.Context, dateObject types.Object) (*Da
 func ValueFrom(ctx context.Context, eventElement *geni.EventElement) (basetypes.ObjectValue, diag.Diagnostics) {
 	var d diag.Diagnostics
 
-	if eventElement != nil {
-		dateObjectValue, diags := DateRangeValueFrom(ctx, eventElement.Date)
-		d.Append(diags...)
-
-		locationObjectValue, diags := LocationValueFrom(ctx, eventElement.Location)
-		d.Append(diags...)
-
-		eventModel := Model{
-			Description: types.StringPointerValue(eventElement.Description),
-			Name:        types.StringValue(eventElement.Name),
-			Date:        dateObjectValue,
-			Location:    locationObjectValue,
-		}
-
-		eventObjectValue, diags := types.ObjectValueFrom(ctx, eventModel.AttributeTypes(), eventModel)
-		d.Append(diags...)
-
-		return eventObjectValue, d
+	if eventElement == nil {
+		return types.ObjectNull(EventModelAttributeTypes()), d
+	}
+	// Geni auto-creates events (e.g. `death = {name: "Death of <name>"}`
+	// when `cause_of_death` is set) that carry only a server-generated
+	// name and no date or location. The schema validator requires every
+	// user-set event to carry date or location, so this shape can only
+	// come from auto-creation; treat it as no event so the refresh plan
+	// does not flap against a config that omits the block.
+	if eventElement.Date == nil && eventElement.Location == nil {
+		return types.ObjectNull(EventModelAttributeTypes()), d
 	}
 
-	return types.ObjectNull(EventModelAttributeTypes()), d
+	dateObjectValue, diags := DateRangeValueFrom(ctx, eventElement.Date)
+	d.Append(diags...)
+
+	locationObjectValue, diags := LocationValueFrom(ctx, eventElement.Location)
+	d.Append(diags...)
+
+	eventModel := Model{
+		Description: types.StringPointerValue(eventElement.Description),
+		Name:        types.StringValue(eventElement.Name),
+		Date:        dateObjectValue,
+		Location:    locationObjectValue,
+	}
+
+	eventObjectValue, diags := types.ObjectValueFrom(ctx, eventModel.AttributeTypes(), eventModel)
+	d.Append(diags...)
+
+	return eventObjectValue, d
 }
 
 func DateValueFrom(ctx context.Context, dateElement *geni.DateElement) (basetypes.ObjectValue, diag.Diagnostics) {

--- a/internal/resource/event/convert_test.go
+++ b/internal/resource/event/convert_test.go
@@ -148,6 +148,46 @@ func TestValueFrom(t *testing.T) {
 		Expect(diags).To(BeEmpty())
 		Expect(result.IsNull()).To(BeTrue())
 	})
+
+	t.Run("event with only a name and no date or location is treated as a server-auto-generated non-event", func(t *testing.T) {
+		RegisterTestingT(t)
+		// Geni auto-creates `death = {name: "Death of <name>"}` whenever
+		// `cause_of_death` is set. The schema validator requires user-set
+		// events to carry date or location, so this shape can only come
+		// from auto-creation and must not flap the refresh plan.
+		eventElement := &geni.EventElement{Name: "Death of John Doe"}
+
+		result, diags := ValueFrom(t.Context(), eventElement)
+
+		Expect(diags).To(BeEmpty())
+		Expect(result.IsNull()).To(BeTrue())
+	})
+
+	t.Run("event with date set is kept regardless of name", func(t *testing.T) {
+		RegisterTestingT(t)
+		eventElement := &geni.EventElement{
+			Name: "Death of John Doe",
+			Date: &geni.DateElement{Year: ptr(int32(1980))},
+		}
+
+		result, diags := ValueFrom(t.Context(), eventElement)
+
+		Expect(diags).To(BeEmpty())
+		Expect(result.IsNull()).To(BeFalse())
+	})
+
+	t.Run("event with location set is kept regardless of name", func(t *testing.T) {
+		RegisterTestingT(t)
+		eventElement := &geni.EventElement{
+			Name:     "Birth of John Doe",
+			Location: &geni.LocationElement{City: ptr("Springfield")},
+		}
+
+		result, diags := ValueFrom(t.Context(), eventElement)
+
+		Expect(diags).To(BeEmpty())
+		Expect(result.IsNull()).To(BeFalse())
+	})
 }
 
 func TestDateValueFrom(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fixes #91. When a user sets `cause_of_death` on a `geni_profile` without a `death` block (and analogously for birth/baptism/burial via other sibling inputs), the Geni API auto-creates the event with only a server-generated `name` (`"Death of John Doe"`) and no `date` or `location`. The provider's Read path lifted that into state, so every refresh against a config that omitted the block flapped `death = {name: ...} -> null`.
- Discriminator lives in `event.ValueFrom`: the schema validator already requires user-set events to carry `date` or `location`, so any API event arriving with both nil is necessarily server-auto-generated and is collapsed to `ObjectNull`. User-set events (which always carry `date` or `location`) round-trip unchanged.
- No schema change, no plan modifier, no write-path change. The fix is entirely local to `event.ValueFrom`.

### Why not Optional + Computed + UseStateForUnknown

The instinctive "mark the event Optional+Computed with `objectplanmodifier.UseStateForUnknown()`" fixes the `cause_of_death` case but breaks `TestAccProfile_removeProfileEvents`, which explicitly asserts that removing event blocks from config results in `event = null` in state. `UseStateForUnknown` preserves state when config is null — wrong direction for that test. The validator-derived discriminator handles both intents correctly.

## Test plan

- [x] `go test ./internal/resource/event/ -run TestValueFrom -v` — two new sub-tests (discriminator triggers; date/location preserve) pass.
- [x] `go test ./... -count=1` — full unit suite green.
- [x] `golangci-lint run` — 0 issues.
- [x] `make docs` — no diff (schema unchanged).
- [x] `TF_ACC=1 go test ./test/acceptance/ -run '^TestAccProfile_removeProfileDeathDetails$'` — flips from FAIL (on `main`) to PASS.
- [x] `TF_ACC=1 go test ./test/acceptance/ -run '^TestAccProfile_removeProfileEvents$'` — stays PASS (no regression on explicit-removal case).
- [x] `TF_ACC=1 go test ./test/acceptance/ -timeout 60m` — 56/57 (the remaining failure, `TestAccUnion_createUnionWithTwoPartnersAndDetails`, reproduces on `main` with the same partner-name reordering symptom — it is pre-existing and unrelated to this change).