### PR TITLE
Fix #94: clearing a date sub-field now actually clears it on Geni

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.19.1 (Unreleased)
 
+BUG FIXES:
+
+* Profile and union: clearing an individual date sub-field (e.g. `birth.date.end_month`, `marriage.date.day`) in HCL while keeping the rest of the date now actually clears it on Geni. The Update path performs a wipe-then-rewrite (one extra PATCH that nulls only the affected event's `date`, followed by the regular PATCH) — Geni's API deep-merges nested objects per-key, so a single PATCH with `"end_month": null` is silently dropped. Adds `geni.Client.WipeEventDates` and a small `event.EventNeedsDatePreWipe` helper that gates the extra PATCH to the case where it is actually needed. (#94)
+
 ## 0.19.0
 
 FEATURES:

--- a/internal/geni/profile.go
+++ b/internal/geni/profile.go
@@ -473,6 +473,44 @@ func (c *Client) UpdateProfile(ctx context.Context, profileId string, request *P
 	return &profile, nil
 }
 
+// WipeEventDates issues a targeted PATCH against /api/<resourceId>/update
+// that nulls only the `date` sub-object of each named event (e.g. `birth`,
+// `baptism`, `death`, `burial` on a profile; `marriage` or `divorce` on a
+// union). Geni's API deep-merges nested objects per-key, which means
+// sending `"end_month": null` inside an otherwise-populated `date` is a
+// no-op — the only way to clear individual date sub-fields is to first
+// wipe the whole `date` and then re-PATCH the desired subset (#94).
+//
+// The request body is hand-crafted to touch only the named events' `date`
+// keys; it deliberately omits `location`, `name`, and `description` to
+// avoid accidentally clearing those alongside the date.
+func (c *Client) WipeEventDates(ctx context.Context, resourceId string, eventKeys []string) error {
+	if len(eventKeys) == 0 {
+		return nil
+	}
+
+	payload := make(map[string]any, len(eventKeys))
+	for _, key := range eventKeys {
+		payload[key] = map[string]any{"date": nil}
+	}
+	jsonBody, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	url := BaseUrl(c.useSandboxEnv) + "api/" + resourceId + "/update"
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(jsonBody))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	if _, err := c.doRequest(ctx, req); err != nil {
+		return err
+	}
+	return nil
+}
+
 type ResultResponse struct {
 	Result string `json:"result,omitempty"`
 }

--- a/internal/resource/event/needs_date_prewipe.go
+++ b/internal/resource/event/needs_date_prewipe.go
@@ -1,0 +1,55 @@
+package event
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// EventNeedsDatePreWipe returns true when applying a Geni profile/union Update
+// requires a pre-wipe PATCH that nulls the event's date object before the
+// regular PATCH writes the new state. Without this, Geni silently drops
+// requests to clear individual numeric/boolean/string sub-fields inside
+// `date` — the API deep-merges nested objects per-key (#94).
+//
+// A pre-wipe is needed iff state and plan both carry a non-null date AND at
+// least one date sub-field is non-null in state but null in plan. Whole-date
+// clears (plan.date == null) and pure adds work via the existing PATCH path.
+func EventNeedsDatePreWipe(state, plan types.Object) bool {
+	stateDate, ok := dateOf(state)
+	if !ok {
+		return false
+	}
+	planDate, ok := dateOf(plan)
+	if !ok {
+		return false
+	}
+
+	stateAttrs := stateDate.Attributes()
+	planAttrs := planDate.Attributes()
+
+	for name, stateVal := range stateAttrs {
+		if stateVal.IsNull() {
+			continue
+		}
+		if planVal, present := planAttrs[name]; present && planVal.IsNull() {
+			return true
+		}
+	}
+	return false
+}
+
+// dateOf returns the date sub-object of the supplied event, or false if the
+// event is null/unknown or has no non-null date.
+func dateOf(event types.Object) (types.Object, bool) {
+	if event.IsNull() || event.IsUnknown() {
+		return types.Object{}, false
+	}
+	dateVal, ok := event.Attributes()["date"]
+	if !ok {
+		return types.Object{}, false
+	}
+	dateObj, ok := dateVal.(types.Object)
+	if !ok || dateObj.IsNull() || dateObj.IsUnknown() {
+		return types.Object{}, false
+	}
+	return dateObj, true
+}

--- a/internal/resource/event/needs_date_prewipe_test.go
+++ b/internal/resource/event/needs_date_prewipe_test.go
@@ -1,0 +1,146 @@
+package event
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	. "github.com/onsi/gomega"
+)
+
+// TestEventNeedsDatePreWipe verifies the rule that decides whether the Geni
+// API needs a pre-wipe PATCH before the main Update can succeed at clearing
+// individual date sub-fields (#94). The rule:
+//
+//   - State and plan both carry a non-null date, AND
+//   - At least one sub-field is non-null in state but null in plan.
+//
+// All other cases (no date in state, plan removing the whole date, plan
+// matching state, plan adding new sub-fields) do not need a pre-wipe.
+func TestEventNeedsDatePreWipe(t *testing.T) {
+	t.Run("Returns false when state has no event", func(t *testing.T) {
+		RegisterTestingT(t)
+		state := types.ObjectNull(EventModelAttributeTypes())
+		plan := eventWithDate(map[string]attr.Value{
+			"year":  types.Int32Value(1900),
+			"month": types.Int32Null(),
+		})
+		Expect(EventNeedsDatePreWipe(state, plan)).To(BeFalse())
+	})
+
+	t.Run("Returns false when plan has no event", func(t *testing.T) {
+		RegisterTestingT(t)
+		state := eventWithDate(map[string]attr.Value{
+			"year":      types.Int32Value(1900),
+			"end_month": types.Int32Value(7),
+		})
+		plan := types.ObjectNull(EventModelAttributeTypes())
+		Expect(EventNeedsDatePreWipe(state, plan)).To(BeFalse())
+	})
+
+	t.Run("Returns false when plan clears the whole date object", func(t *testing.T) {
+		RegisterTestingT(t)
+		state := eventWithDate(map[string]attr.Value{
+			"year":      types.Int32Value(1900),
+			"end_month": types.Int32Value(7),
+		})
+		plan := eventWithNullDate()
+		Expect(EventNeedsDatePreWipe(state, plan)).To(BeFalse())
+	})
+
+	t.Run("Returns false when state and plan dates are equal", func(t *testing.T) {
+		RegisterTestingT(t)
+		fields := map[string]attr.Value{
+			"year":      types.Int32Value(1900),
+			"end_month": types.Int32Value(7),
+		}
+		Expect(EventNeedsDatePreWipe(eventWithDate(fields), eventWithDate(fields))).To(BeFalse())
+	})
+
+	t.Run("Returns false when plan only adds new sub-fields", func(t *testing.T) {
+		RegisterTestingT(t)
+		state := eventWithDate(map[string]attr.Value{
+			"year": types.Int32Value(1900),
+		})
+		plan := eventWithDate(map[string]attr.Value{
+			"year":  types.Int32Value(1900),
+			"month": types.Int32Value(7),
+		})
+		Expect(EventNeedsDatePreWipe(state, plan)).To(BeFalse())
+	})
+
+	t.Run("Returns true when plan clears a numeric sub-field", func(t *testing.T) {
+		RegisterTestingT(t)
+		state := eventWithDate(map[string]attr.Value{
+			"year":      types.Int32Value(1752),
+			"end_year":  types.Int32Value(1799),
+			"end_month": types.Int32Value(7),
+			"range":     types.StringValue("between"),
+		})
+		plan := eventWithDate(map[string]attr.Value{
+			"year":     types.Int32Value(1752),
+			"end_year": types.Int32Value(1799),
+			"range":    types.StringValue("between"),
+		})
+		Expect(EventNeedsDatePreWipe(state, plan)).To(BeTrue())
+	})
+
+	t.Run("Returns true when plan clears a boolean sub-field", func(t *testing.T) {
+		RegisterTestingT(t)
+		state := eventWithDate(map[string]attr.Value{
+			"year":      types.Int32Value(1900),
+			"end_circa": types.BoolValue(true),
+		})
+		plan := eventWithDate(map[string]attr.Value{
+			"year": types.Int32Value(1900),
+		})
+		Expect(EventNeedsDatePreWipe(state, plan)).To(BeTrue())
+	})
+
+	t.Run("Returns true when plan clears a string sub-field", func(t *testing.T) {
+		RegisterTestingT(t)
+		state := eventWithDate(map[string]attr.Value{
+			"year":  types.Int32Value(1900),
+			"range": types.StringValue("before"),
+		})
+		plan := eventWithDate(map[string]attr.Value{
+			"year": types.Int32Value(1900),
+		})
+		Expect(EventNeedsDatePreWipe(state, plan)).To(BeTrue())
+	})
+}
+
+// eventWithDate builds an event object whose date sub-object carries the
+// supplied fields; any field not in `fields` is null.
+func eventWithDate(fields map[string]attr.Value) types.Object {
+	full := map[string]attr.Value{
+		"range":     types.StringNull(),
+		"circa":     types.BoolNull(),
+		"day":       types.Int32Null(),
+		"month":     types.Int32Null(),
+		"year":      types.Int32Null(),
+		"end_circa": types.BoolNull(),
+		"end_day":   types.Int32Null(),
+		"end_month": types.Int32Null(),
+		"end_year":  types.Int32Null(),
+	}
+	for k, v := range fields {
+		full[k] = v
+	}
+	dateObj := types.ObjectValueMust(DateRangeModelAttributeTypes(), full)
+	return types.ObjectValueMust(EventModelAttributeTypes(), map[string]attr.Value{
+		"name":        types.StringNull(),
+		"description": types.StringNull(),
+		"date":        dateObj,
+		"location":    types.ObjectNull(LocationModelAttributeTypes()),
+	})
+}
+
+func eventWithNullDate() types.Object {
+	return types.ObjectValueMust(EventModelAttributeTypes(), map[string]attr.Value{
+		"name":        types.StringNull(),
+		"description": types.StringNull(),
+		"date":        types.ObjectNull(DateRangeModelAttributeTypes()),
+		"location":    types.ObjectNull(LocationModelAttributeTypes()),
+	})
+}

--- a/internal/resource/profile/update.go
+++ b/internal/resource/profile/update.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/dmalch/terraform-provider-genealogy/internal/geni"
+	"github.com/dmalch/terraform-provider-genealogy/internal/resource/event"
 )
 
 // Update updates the resource.
@@ -48,6 +49,17 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		return
 	}
 
+	// Geni's PATCH deep-merges nested objects per-key, so clearing individual
+	// date sub-fields needs a wipe-then-rewrite (#94). Issue the pre-wipe only
+	// for events where the plan keeps the date but clears at least one sub-field.
+	wipeEvents := planDateWipes(state, plan)
+	if len(wipeEvents) > 0 {
+		if err := r.client.WipeEventDates(ctx, plan.ID.ValueString(), wipeEvents); err != nil {
+			resp.Diagnostics.AddError("Error clearing date fields", err.Error())
+			return
+		}
+	}
+
 	profileResponse, err := r.client.UpdateProfile(ctx, plan.ID.ValueString(), profileRequest)
 	if err != nil {
 		resp.Diagnostics.AddError("Error updating profile", err.Error())
@@ -73,6 +85,27 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 	// Set data returned by API in identity
 	identityData.ID = types.StringValue(profileResponse.Id)
 	resp.Diagnostics.Append(resp.Identity.Set(ctx, identityData)...)
+}
+
+// planDateWipes lists the event keys whose date sub-object the Update path
+// must pre-wipe before sending the regular PATCH. Order is fixed for
+// determinism in tests and to match the API payload shape.
+func planDateWipes(state, plan ResourceModel) []string {
+	var wipes []string
+	for _, e := range []struct {
+		name        string
+		state, plan types.Object
+	}{
+		{"birth", state.Birth, plan.Birth},
+		{"baptism", state.Baptism, plan.Baptism},
+		{"death", state.Death, plan.Death},
+		{"burial", state.Burial, plan.Burial},
+	} {
+		if event.EventNeedsDatePreWipe(e.state, e.plan) {
+			wipes = append(wipes, e.name)
+		}
+	}
+	return wipes
 }
 
 func findRemovedKeys(stateAbout types.Map, planAbout types.Map) []string {

--- a/internal/resource/union/update.go
+++ b/internal/resource/union/update.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 
 	"github.com/dmalch/terraform-provider-genealogy/internal/geni"
+	"github.com/dmalch/terraform-provider-genealogy/internal/resource/event"
 )
 
 // Update updates the resource.
@@ -167,6 +168,23 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
 			return
+		}
+
+		// Pre-wipe event dates that the plan partially clears — Geni's PATCH
+		// deep-merges nested objects so per-key nulls inside `date` are no-ops
+		// (#94). Cost is one extra PATCH per Update that hits this case.
+		var wipeEvents []string
+		if event.EventNeedsDatePreWipe(state.Marriage, plan.Marriage) {
+			wipeEvents = append(wipeEvents, "marriage")
+		}
+		if event.EventNeedsDatePreWipe(state.Divorce, plan.Divorce) {
+			wipeEvents = append(wipeEvents, "divorce")
+		}
+		if len(wipeEvents) > 0 {
+			if err := r.client.WipeEventDates(ctx, plan.ID.ValueString(), wipeEvents); err != nil {
+				resp.Diagnostics.AddError("Error clearing date fields", err.Error())
+				return
+			}
 		}
 
 		unionResponse, err := r.client.UpdateUnion(ctx, plan.ID.ValueString(), unionRequest)

--- a/test/acceptance/geni_profile_test.go
+++ b/test/acceptance/geni_profile_test.go
@@ -1230,3 +1230,106 @@ func TestAccProfile_removeProfileAboutSection(t *testing.T) {
 		},
 	})
 }
+
+// TestAccProfile_clearDateSubFieldPersists exercises the issue #94 reproducer:
+// a between-range birth.date with end_month=7 is narrowed by removing
+// end_month from HCL while keeping range/year/end_year/end_circa. The fix
+// performs a wipe-then-rewrite, so after apply Geni's stored date matches
+// the plan exactly. The third step rolls the same config forward as PlanOnly
+// to assert that a follow-up refresh+plan is empty (no drift).
+func TestAccProfile_clearDateSubFieldPersists(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					resource "geni_profile" "test" {
+					  names = {
+						"en-US" = {
+							first_name = "Darja"
+							last_name  = "Adrianovna"
+						}
+					  }
+					  alive  = false
+					  public = true
+					  birth = {
+						date = {
+						  range     = "between"
+						  circa     = true
+						  year      = 1752
+						  end_circa = true
+						  end_year  = 1799
+						  end_month = 7
+						}
+					  }
+					}
+				`,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("geni_profile.test", tfjsonpath.New("birth").AtMapKey("date").AtMapKey("end_month"), knownvalue.Int32Exact(7)),
+					statecheck.ExpectKnownValue("geni_profile.test", tfjsonpath.New("birth").AtMapKey("date").AtMapKey("year"), knownvalue.Int32Exact(1752)),
+					statecheck.ExpectKnownValue("geni_profile.test", tfjsonpath.New("birth").AtMapKey("date").AtMapKey("end_year"), knownvalue.Int32Exact(1799)),
+				},
+			},
+			{
+				Config: `
+					resource "geni_profile" "test" {
+					  names = {
+						"en-US" = {
+							first_name = "Darja"
+							last_name  = "Adrianovna"
+						}
+					  }
+					  alive  = false
+					  public = true
+					  birth = {
+						date = {
+						  range     = "between"
+						  circa     = true
+						  year      = 1752
+						  end_circa = true
+						  end_year  = 1799
+						  # end_month intentionally absent
+						}
+					  }
+					}
+				`,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("geni_profile.test", tfjsonpath.New("birth").AtMapKey("date").AtMapKey("end_month"), knownvalue.Null()),
+					statecheck.ExpectKnownValue("geni_profile.test", tfjsonpath.New("birth").AtMapKey("date").AtMapKey("year"), knownvalue.Int32Exact(1752)),
+					statecheck.ExpectKnownValue("geni_profile.test", tfjsonpath.New("birth").AtMapKey("date").AtMapKey("end_year"), knownvalue.Int32Exact(1799)),
+					statecheck.ExpectKnownValue("geni_profile.test", tfjsonpath.New("birth").AtMapKey("date").AtMapKey("end_circa"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue("geni_profile.test", tfjsonpath.New("birth").AtMapKey("date").AtMapKey("range"), knownvalue.StringExact("between")),
+				},
+			},
+			{
+				// Refresh + plan only. Before the fix this step would fail
+				// because Geni still has end_month=7 server-side, so the plan
+				// would re-show `~ end_month = 7 -> null`. ExpectNonEmptyPlan
+				// defaults to false, so an empty plan here is the assertion.
+				Config: `
+					resource "geni_profile" "test" {
+					  names = {
+						"en-US" = {
+							first_name = "Darja"
+							last_name  = "Adrianovna"
+						}
+					  }
+					  alive  = false
+					  public = true
+					  birth = {
+						date = {
+						  range     = "between"
+						  circa     = true
+						  year      = 1752
+						  end_circa = true
+						  end_year  = 1799
+						}
+					  }
+					}
+				`,
+				PlanOnly: true,
+			},
+		},
+	})
+}


### PR DESCRIPTION
Closes #94.

## Summary

When an HCL `geni_profile` (or `geni_union`) config flipped a date sub-attribute like `birth.date.end_month` from a non-null value to `null`, the provider's PATCH returned 200 OK but Geni silently dropped the change — every subsequent `terraform plan` re-showed the same `-> null` diff forever. Geni's API deep-merges nested objects per-key, so `"end_month": null` (or `0`, `""`, or omitting the key) is interpreted as "no change to this field".

## What I tried, what works

Probed the sandbox API directly (eight payload variants — see commit message for the full list):

- ❌ `"end_month": null`, `0`, `""`, omitting the key, replacing the whole `date` with explicit `null`s — all leave the value at 7.
- ✅ `"date": null` and `"date": {}` wipe the **whole** date object.
- ✅ **Wipe-then-rewrite** (PATCH `date: null`, then PATCH the desired date sans the cleared field) lands the profile with `end_month=nil` and every other sub-field preserved.

## The fix

Update path now performs wipe-then-rewrite when, and only when, the plan keeps the date but clears at least one sub-field:

1. PATCH `{"<event>":{"date":null}}` to wipe just the affected events. The body is hand-crafted to touch only the `date` key, so `location`, `name`, and `description` survive.
2. PATCH the normal Update payload — the new date lands with the cleared sub-fields genuinely null.

Cost: one extra rate-limited PATCH per Update that triggers the case. The new `event.EventNeedsDatePreWipe` helper gates the extra call so it only fires when actually needed.

## Pieces

- `internal/resource/event/needs_date_prewipe.go` + `_test.go` — pure helper that decides "does this event need a pre-wipe?". 8 cases.
- `internal/geni/profile.go` — `Client.WipeEventDates(ctx, resourceId, eventKeys)` issues the raw targeted PATCH.
- `internal/resource/profile/update.go` + `internal/resource/union/update.go` — wired before the regular `UpdateProfile` / `UpdateUnion` call.
- `test/acceptance/geni_profile_test.go` — `TestAccProfile_clearDateSubFieldPersists` reproduces the issue end-to-end: create with `end_month=7`, update to clear it, then re-plan with PlanOnly to assert no drift. **Verified to fail without the fix** with exactly `- end_month = 7 -> null` (the issue's symptom); passes with the fix.

## Test plan

- [x] `go test ./...` — green.
- [x] `golangci-lint run` — 0 issues.
- [x] `TF_ACC=1 go test ./test/acceptance/ -run TestAccProfile_clearDateSubFieldPersists` — passes (14s).
- [x] Regression sweep: full `TF_ACC=1 go test ./test/acceptance/ -timeout 30m`. One pre-existing flake fired (`TestAccUnion_createUnionWithTwoPartnersAndDetails`, partner-ordering instability on Geni's API, see prior context); passes in isolation on retry. Not introduced by this PR.

## Release

Scheduled for `v0.19.1` (CHANGELOG entry under BUG FIXES).