### PR TITLE
Fix #94 follow-up: empty-object sentinel for date wipe (covers unions)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.19.2 (Unreleased)
 
+BUG FIXES:
+
+* Union: clearing an individual `marriage.date` or `divorce.date` sub-field now actually clears it on Geni. v0.19.1 shipped the wipe-then-rewrite plumbing for both profile and union Update paths, but the wipe sentinel was `"date": null` — which the profile endpoint honors but the union endpoint silently ignores. Switched to `"date": {}` (empty object), which Geni accepts uniformly on both endpoints. Adds a union acceptance test that locks in the behaviour. (#94)
+
 ## 0.19.1
 
 BUG FIXES:

--- a/internal/geni/profile.go
+++ b/internal/geni/profile.go
@@ -489,9 +489,12 @@ func (c *Client) WipeEventDates(ctx context.Context, resourceId string, eventKey
 		return nil
 	}
 
+	// "date": {} (empty object) is the only sentinel both the profile and
+	// union endpoints honor as a date wipe. "date": null wipes on profile but
+	// is silently ignored on union.
 	payload := make(map[string]any, len(eventKeys))
 	for _, key := range eventKeys {
-		payload[key] = map[string]any{"date": nil}
+		payload[key] = map[string]any{"date": map[string]any{}}
 	}
 	jsonBody, err := json.Marshal(payload)
 	if err != nil {

--- a/test/acceptance/geni_union_test.go
+++ b/test/acceptance/geni_union_test.go
@@ -1209,3 +1209,109 @@ func TestAccUnion_addFosterChildToExistingUnion(t *testing.T) {
 		},
 	})
 }
+
+// TestAccUnion_clearMarriageDateSubFieldPersists exercises the wipe-then-rewrite
+// path on the union resource (#94 sibling coverage): a between-range
+// marriage.date with end_month=7 is narrowed by removing end_month from HCL
+// while keeping the rest of the date. The third step rolls the same config
+// forward as PlanOnly to assert that the follow-up refresh+plan is empty.
+func TestAccUnion_clearMarriageDateSubFieldPersists(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					resource "geni_profile" "husband" {
+					  names = { "en-US" = { first_name = "John", last_name = "Doe" } }
+					  alive  = false
+					  public = true
+					}
+					resource "geni_profile" "wife" {
+					  names = { "en-US" = { first_name = "Jane", last_name = "Doe" } }
+					  alive  = false
+					  public = true
+					}
+					resource "geni_union" "doe_family" {
+					  partners = [geni_profile.husband.id, geni_profile.wife.id]
+					  marriage = {
+						date = {
+						  range     = "between"
+						  circa     = true
+						  year      = 1752
+						  end_circa = true
+						  end_year  = 1799
+						  end_month = 7
+						}
+					  }
+					}
+				`,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("geni_union.doe_family", tfjsonpath.New("marriage").AtMapKey("date").AtMapKey("end_month"), knownvalue.Int32Exact(7)),
+				},
+			},
+			{
+				Config: `
+					resource "geni_profile" "husband" {
+					  names = { "en-US" = { first_name = "John", last_name = "Doe" } }
+					  alive  = false
+					  public = true
+					}
+					resource "geni_profile" "wife" {
+					  names = { "en-US" = { first_name = "Jane", last_name = "Doe" } }
+					  alive  = false
+					  public = true
+					}
+					resource "geni_union" "doe_family" {
+					  partners = [geni_profile.husband.id, geni_profile.wife.id]
+					  marriage = {
+						date = {
+						  range     = "between"
+						  circa     = true
+						  year      = 1752
+						  end_circa = true
+						  end_year  = 1799
+						  # end_month intentionally absent
+						}
+					  }
+					}
+				`,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("geni_union.doe_family", tfjsonpath.New("marriage").AtMapKey("date").AtMapKey("end_month"), knownvalue.Null()),
+					statecheck.ExpectKnownValue("geni_union.doe_family", tfjsonpath.New("marriage").AtMapKey("date").AtMapKey("year"), knownvalue.Int32Exact(1752)),
+					statecheck.ExpectKnownValue("geni_union.doe_family", tfjsonpath.New("marriage").AtMapKey("date").AtMapKey("end_year"), knownvalue.Int32Exact(1799)),
+					statecheck.ExpectKnownValue("geni_union.doe_family", tfjsonpath.New("marriage").AtMapKey("date").AtMapKey("end_circa"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue("geni_union.doe_family", tfjsonpath.New("marriage").AtMapKey("date").AtMapKey("range"), knownvalue.StringExact("between")),
+				},
+			},
+			{
+				// Refresh + plan only. Asserts no drift on Geni's side.
+				Config: `
+					resource "geni_profile" "husband" {
+					  names = { "en-US" = { first_name = "John", last_name = "Doe" } }
+					  alive  = false
+					  public = true
+					}
+					resource "geni_profile" "wife" {
+					  names = { "en-US" = { first_name = "Jane", last_name = "Doe" } }
+					  alive  = false
+					  public = true
+					}
+					resource "geni_union" "doe_family" {
+					  partners = [geni_profile.husband.id, geni_profile.wife.id]
+					  marriage = {
+						date = {
+						  range     = "between"
+						  circa     = true
+						  year      = 1752
+						  end_circa = true
+						  end_year  = 1799
+						}
+					  }
+					}
+				`,
+				PlanOnly: true,
+			},
+		},
+	})
+}


### PR DESCRIPTION
v0.19.1 fixed date sub-field clearing on `geni_profile` but did not actually work on `geni_union`. The bug was masked by the profile-only acceptance test coverage that shipped with that release.

## What I learned

Direct sandbox probes against `/api/<id>/update` show the two endpoints disagree on the wipe sentinel:

| Endpoint | `"date": null` | `"date": {}` | `"marriage": null` |
|---|---|---|---|
| profile | wipes ✅ | wipes ✅ | n/a |
| union | no-op ❌ | wipes ✅ | 500 \"value must be a hash!\" |

`"date": {}` is the only sentinel both endpoints accept uniformly.

## Changes

- `internal/geni/profile.go` — `WipeEventDates` now sends `"date": {}` instead of `"date": null`. One-line change plus an explanatory comment.
- `test/acceptance/geni_union_test.go` — `TestAccUnion_clearMarriageDateSubFieldPersists` mirrors the existing profile test (3-step: apply with `end_month=7`, apply clearing it, plan-only to assert no drift). Verified red against the v0.19.1 sentinel and green with the new one.

## Test plan

- [x] `go test ./...` — unit suite green.
- [x] `TF_ACC=1 go test ./test/acceptance/ -run 'TestAccProfile_clearDateSubFieldPersists|TestAccUnion_clearMarriageDateSubFieldPersists'` — both pass (14.6s + 33.9s).

Scheduled for `v0.19.2` (CHANGELOG entry under BUG FIXES).