### PR TITLE
Add geni_profile.title / suffix / occupation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.19.3 (Unreleased)
+## 0.20.0 (Unreleased)
 
 FEATURES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.19.3 (Unreleased)
 
+FEATURES:
+
+* `geni_profile`: new optional attributes `title`, `suffix`, and `occupation`, surfacing the matching Geni profile fields. Clearing them in HCL now sends `""` to Geni so the server-side value is genuinely removed. The new `geni_profile` data source returns the same three attributes as computed values.
+
 ## 0.19.2
 
 BUG FIXES:

--- a/docs/data-sources/profile.md
+++ b/docs/data-sources/profile.md
@@ -35,8 +35,11 @@ Look up a single Geni profile by `id` or `guid`. Exactly one must be set.
 - `gender` (String) Profile's gender.
 - `merged_into` (String) The ID of the profile this profile was merged into, if any.
 - `names` (Attributes Map) Nested map of locale → name fields. (see [below for nested schema](#nestedatt--names))
+- `occupation` (String) Profile's occupation.
 - `projects` (Set of String) List of project IDs the profile is a member of.
 - `public` (Boolean) Profile's public visibility.
+- `suffix` (String) Profile's name suffix (e.g. "Jr.", "III").
+- `title` (String) Profile's name title (e.g. "Dr.", "Sir").
 - `unions` (Set of String) List of union IDs the profile belongs to.
 
 <a id="nestedatt--baptism"></a>

--- a/docs/resources/profile.md
+++ b/docs/resources/profile.md
@@ -35,7 +35,10 @@ description: |-
 - `id` (String) The unique identifier for the profile. This is a string that starts with 'profile-' followed by a number.
 - `merged_into` (String) The ID of the profile this profile was merged into.
 - `names` (Attributes Map) Nested maps of locales to name fields to values. (see [below for nested schema](#nestedatt--names))
+- `occupation` (String) Profile's occupation.
 - `projects` (Set of String) List of project IDs.
+- `suffix` (String) Profile's name suffix (e.g. "Jr.", "III").
+- `title` (String) Profile's name title (e.g. "Dr.", "Sir").
 - `unions` (Set of String) List of union IDs.
 
 ### Read-Only

--- a/internal/datasource/profile/schema.go
+++ b/internal/datasource/profile/schema.go
@@ -44,6 +44,18 @@ func (d *DataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp 
 				Computed:    true,
 				Description: "Profile's gender.",
 			},
+			"title": schema.StringAttribute{
+				Computed:    true,
+				Description: "Profile's name title (e.g. \"Dr.\", \"Sir\").",
+			},
+			"suffix": schema.StringAttribute{
+				Computed:    true,
+				Description: "Profile's name suffix (e.g. \"Jr.\", \"III\").",
+			},
+			"occupation": schema.StringAttribute{
+				Computed:    true,
+				Description: "Profile's occupation.",
+			},
 			"names": schema.MapNestedAttribute{
 				Computed: true,
 				NestedObject: schema.NestedAttributeObject{

--- a/internal/geni/profile.go
+++ b/internal/geni/profile.go
@@ -38,18 +38,20 @@ type ProfileRequest struct {
 	Burial *EventElement `json:"burial,omitempty"`
 	// IsAlive is a boolean that indicates whether the profile is living
 	IsAlive bool `json:"is_alive"`
-	// Title is the profile's name title
-	Title string `json:"title,omitempty"`
+	// Title is the profile's name title. Sent without omitempty so that an
+	// empty string clears any previously-set value (Geni accepts "" as a
+	// clear sentinel for flat scalar fields).
+	Title string `json:"title"`
 	// CurrentResidence is the profile's current residence
 	CurrentResidence *LocationElement `json:"current_residence"`
 	// AboutMe is the profile's about me section
 	AboutMe *string `json:"about_me"`
 	// DetailStrings are nested maps of locales to details fields (e.g. about me) to values
 	DetailStrings map[string]DetailsString `json:"detail_strings"`
-	// Occupation is the profile's occupation
-	Occupation string `json:"occupation,omitempty"`
-	// Suffix is the profile's suffix
-	Suffix string `json:"suffix,omitempty"`
+	// Occupation is the profile's occupation. Sent without omitempty — see Title.
+	Occupation string `json:"occupation"`
+	// Suffix is the profile's suffix. Sent without omitempty — see Title.
+	Suffix string `json:"suffix"`
 	// Public is a boolean that indicates whether the profile is public
 	Public bool `json:"public"`
 	// Locked is a boolean that indicates whether the profile is locked down by a curator
@@ -357,7 +359,7 @@ func (c *Client) GetProfile(ctx context.Context, profileId string) (*ProfileResp
 
 func (c *Client) addProfileFieldsQueryParams(req *http.Request) {
 	query := req.URL.Query()
-	query.Add("fields", "id,guid,first_name,last_name,middle_name,maiden_name,display_name,nicknames,names,gender,birth,baptism,death,burial,cause_of_death,current_residence,about_me,detail_strings,unions,project_ids,is_alive,public,deleted,merged_into,updated_at,created_at")
+	query.Add("fields", "id,guid,first_name,last_name,middle_name,maiden_name,display_name,nicknames,names,gender,title,suffix,occupation,birth,baptism,death,burial,cause_of_death,current_residence,about_me,detail_strings,unions,project_ids,is_alive,public,deleted,merged_into,updated_at,created_at")
 	req.URL.RawQuery = query.Encode()
 }
 

--- a/internal/resource/profile/convert.go
+++ b/internal/resource/profile/convert.go
@@ -25,6 +25,10 @@ func ValueFrom(ctx context.Context, profile *geni.ProfileResponse, profileModel 
 		profileModel.Guid = types.StringNull()
 	}
 
+	profileModel.Title = optionalString(profile.Title)
+	profileModel.Occupation = optionalString(profile.Occupation)
+	profileModel.Suffix = optionalString(profile.Suffix)
+
 	profileModel.Gender = types.StringPointerValue(profile.Gender)
 
 	detailStrings, diags := detailStringsValueFrom(ctx, profile)
@@ -219,6 +223,9 @@ func RequestFrom(ctx context.Context, resourceModel ResourceModel) (*geni.Profil
 		DetailStrings:    convertedDetails,
 		Public:           resourceModel.Public.ValueBool(),
 		IsAlive:          resourceModel.Alive.ValueBool(),
+		Title:            resourceModel.Title.ValueString(),
+		Occupation:       resourceModel.Occupation.ValueString(),
+		Suffix:           resourceModel.Suffix.ValueString(),
 	}
 
 	return profileRequest, d
@@ -311,6 +318,17 @@ func UpdateComputedFields(ctx context.Context, profile *geni.ProfileResponse, pr
 	profileModel.CreatedAt = types.StringValue(profile.CreatedAt)
 
 	return d
+}
+
+// optionalString maps a Geni API string field (where "" means "not set") to a
+// Terraform-framework optional string: empty becomes null, non-empty becomes
+// the value. Used for plain string fields like title/occupation/suffix that
+// the API returns omitempty.
+func optionalString(s string) types.String {
+	if s == "" {
+		return types.StringNull()
+	}
+	return types.StringValue(s)
 }
 
 func convertToSlice(ctx context.Context, set types.Set) ([]string, diag.Diagnostics) {

--- a/internal/resource/profile/convert_test.go
+++ b/internal/resource/profile/convert_test.go
@@ -37,8 +37,11 @@ func TestValueFrom(t *testing.T) {
 					LastName:   ptr("Doe"),
 				},
 			},
-			Unions:   []string{"union1", "union2"},
-			Projects: []string{"project-4505748", "project-4497781"},
+			Unions:     []string{"union1", "union2"},
+			Projects:   []string{"project-4505748", "project-4497781"},
+			Title:      "Dr.",
+			Occupation: "Astronaut",
+			Suffix:     "Jr.",
 			Birth: &geni.EventElement{
 				Date: &geni.DateElement{
 					Day:   ptr[int32](1),
@@ -76,6 +79,9 @@ func TestValueFrom(t *testing.T) {
 		Expect(diags.HasError()).To(BeFalse())
 		Expect(actualValue.ID.ValueString()).To(Equal(givenProfile.Id))
 		Expect(actualValue.Guid.ValueString()).To(Equal(givenProfile.Guid))
+		Expect(actualValue.Title.ValueString()).To(Equal(givenProfile.Title))
+		Expect(actualValue.Occupation.ValueString()).To(Equal(givenProfile.Occupation))
+		Expect(actualValue.Suffix.ValueString()).To(Equal(givenProfile.Suffix))
 		Expect(actualValue.Gender.ValueString()).To(Equal(*givenProfile.Gender))
 		var actualAbout = make(map[string]string)
 		Expect(actualValue.About.ElementsAs(t.Context(), &actualAbout, false).HasError()).To(BeFalse())
@@ -179,6 +185,9 @@ func TestRequestFrom(t *testing.T) {
 			Burial:           types.ObjectNull(event.EventModelAttributeTypes()),
 			CauseOfDeath:     types.StringNull(),
 			CurrentResidence: types.ObjectNull(event.LocationModelAttributeTypes()),
+			Title:            types.StringValue("Dr."),
+			Occupation:       types.StringValue("Astronaut"),
+			Suffix:           types.StringValue("Jr."),
 		}
 
 		request, diags := RequestFrom(t.Context(), givenModel)
@@ -188,6 +197,9 @@ func TestRequestFrom(t *testing.T) {
 		Expect(request.Gender).To(HaveValue(Equal("male")))
 		Expect(request.IsAlive).To(BeTrue())
 		Expect(request.Public).To(BeTrue())
+		Expect(request.Title).To(Equal("Dr."))
+		Expect(request.Occupation).To(Equal("Astronaut"))
+		Expect(request.Suffix).To(Equal("Jr."))
 		Expect(request.Names).To(HaveLen(1))
 		Expect(request.Names["en"].FirstName).To(HaveValue(Equal("John")))
 		Expect(request.Names["en"].LastName).To(HaveValue(Equal("Doe")))

--- a/internal/resource/profile/model.go
+++ b/internal/resource/profile/model.go
@@ -31,6 +31,9 @@ type ResourceModel struct {
 	ID               types.String `tfsdk:"id"`
 	Guid             types.String `tfsdk:"guid"`
 	Names            types.Map    `tfsdk:"names"`
+	Title            types.String `tfsdk:"title"`
+	Suffix           types.String `tfsdk:"suffix"`
+	Occupation       types.String `tfsdk:"occupation"`
 	Gender           types.String `tfsdk:"gender"`
 	Birth            types.Object `tfsdk:"birth"`
 	Baptism          types.Object `tfsdk:"baptism"`

--- a/internal/resource/profile/schema.go
+++ b/internal/resource/profile/schema.go
@@ -47,6 +47,18 @@ func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *res
 				Validators:  []validator.String{stringvalidator.OneOf("female", "male")},
 				Description: "Profile's gender.",
 			},
+			"title": schema.StringAttribute{
+				Optional:    true,
+				Description: "Profile's name title (e.g. \"Dr.\", \"Sir\").",
+			},
+			"suffix": schema.StringAttribute{
+				Optional:    true,
+				Description: "Profile's name suffix (e.g. \"Jr.\", \"III\").",
+			},
+			"occupation": schema.StringAttribute{
+				Optional:    true,
+				Description: "Profile's occupation.",
+			},
 			"names": schema.MapNestedAttribute{
 				Optional: true,
 				NestedObject: schema.NestedAttributeObject{

--- a/test/acceptance/geni_profile_test.go
+++ b/test/acceptance/geni_profile_test.go
@@ -1333,3 +1333,63 @@ func TestAccProfile_clearDateSubFieldPersists(t *testing.T) {
 		},
 	})
 }
+
+// TestAccProfile_titleOccupationSuffix exercises the additive title/suffix/
+// occupation fields end-to-end against the sandbox: create with all three
+// set, then update to clear them. Step 3 plan-only asserts no drift.
+func TestAccProfile_titleOccupationSuffix(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					resource "geni_profile" "test" {
+					  names = {
+						"en-US" = { first_name = "John", last_name = "Doe" }
+					  }
+					  alive      = false
+					  public     = true
+					  title      = "Dr."
+					  suffix     = "Jr."
+					  occupation = "Astronaut"
+					}
+				`,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("geni_profile.test", tfjsonpath.New("title"), knownvalue.StringExact("Dr.")),
+					statecheck.ExpectKnownValue("geni_profile.test", tfjsonpath.New("suffix"), knownvalue.StringExact("Jr.")),
+					statecheck.ExpectKnownValue("geni_profile.test", tfjsonpath.New("occupation"), knownvalue.StringExact("Astronaut")),
+				},
+			},
+			{
+				Config: `
+					resource "geni_profile" "test" {
+					  names = {
+						"en-US" = { first_name = "John", last_name = "Doe" }
+					  }
+					  alive  = false
+					  public = true
+					  # title/suffix/occupation intentionally absent
+					}
+				`,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("geni_profile.test", tfjsonpath.New("title"), knownvalue.Null()),
+					statecheck.ExpectKnownValue("geni_profile.test", tfjsonpath.New("suffix"), knownvalue.Null()),
+					statecheck.ExpectKnownValue("geni_profile.test", tfjsonpath.New("occupation"), knownvalue.Null()),
+				},
+			},
+			{
+				Config: `
+					resource "geni_profile" "test" {
+					  names = {
+						"en-US" = { first_name = "John", last_name = "Doe" }
+					  }
+					  alive  = false
+					  public = true
+					}
+				`,
+				PlanOnly: true,
+			},
+		},
+	})
+}


### PR DESCRIPTION
Surfaces three writable Geni profile fields the provider didn't model yet.

## What's new

| Attribute | Type | Notes |
|---|---|---|
| `title` | optional string | e.g. \"Dr.\", \"Sir\" |
| `suffix` | optional string | e.g. \"Jr.\", \"III\" |
| `occupation` | optional string | free-text |

All three are surfaced on the `geni_profile` resource and on the `data \"geni_profile\"` data source (as computed). The shared `fields=` query parameter on every profile read path now requests them so reads round-trip.

## The clear-sentinel subtlety

Geni's API accepts both `null` and `\"\"` to clear a flat scalar profile field. The provider's `ProfileRequest` struct previously tagged these three fields with `omitempty`, which means the Go JSON marshaller drops the key entirely when the value is `\"\"` — and Geni interprets a missing key as \"no change\" (the same deep-merge behaviour that caused #94). Dropping `omitempty` makes the marshaller emit `\"title\": \"\"` so removing the attribute from HCL genuinely clears it.

Verified via sandbox probe (probe code discarded; permanent regression test below).

## Test plan

- [x] `go test ./...` — unit tests green; `TestValueFrom` and `TestRequestFrom` now cover the three new fields on both directions.
- [x] `golangci-lint run` — 0 issues.
- [x] `make docs` — `docs/resources/profile.md` and `docs/data-sources/profile.md` regenerated.
- [x] `TF_ACC=1 go test ./test/acceptance/ -run TestAccProfile_titleOccupationSuffix` — 3-step test (set all three → clear all three → plan-only assert no drift) green (12.5s).

Scheduled for v0.19.3 (CHANGELOG entry under FEATURES).