### PR TITLE
docs(readme): sync with v0.18–v0.20 surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     geni = {
       source  = "dmalch/genealogy"
-      version = "~> 0.16"
+      version = "~> 0.20"
     }
   }
 }
@@ -59,6 +59,9 @@ resource "geni_profile" "mother" {
 }
 
 resource "geni_profile" "father" {
+  title      = "Dr."
+  occupation = "Historian"
+
   names = {
     "en-US" = {
       first_name  = "John"
@@ -133,13 +136,50 @@ document forces Terraform to destroy and recreate it.
 
 ## Data Sources
 
+Look up an existing project or profile without taking ownership of it.
+
 ```hcl
 data "geni_project" "example" {
-  # Provide a valid project ID or lookup
-  # You can reference this data source in other resources
-  project_id = "project-67890"
+  id = "project-12345" # format: "project-<numeric>"
+}
+
+# Look up by canonical id…
+data "geni_profile" "founder" {
+  id = "profile-12345"
+}
+
+# …or by GUID. Exactly one of `id` or `guid` is required.
+data "geni_profile" "founder_by_guid" {
+  guid = "abcdef0123456789"
 }
 ```
+
+When the provider's `auto_update_merged_profiles` flag is set, the
+`geni_profile` data source follows `merged_into` chains (up to ten hops) so
+you can reference a profile by its historical id and still get the surviving
+record.
+
+## Discovery (Terraform 1.14+)
+
+Use `terraform query` to enumerate profiles or documents you already manage on
+Geni so you can paste their identities into `import {}` blocks — closing the
+discover-then-import workflow without having to look up numeric IDs by hand.
+
+```hcl
+list "geni_profile" "all" {
+  provider = geni
+}
+
+list "geni_document" "all" {
+  provider = geni
+}
+```
+
+Each result carries an `identity = { id = "..." }` that drops straight into an
+`import { identity = { id = "profile-NNN" } to = geni_profile.<label> }`
+block. Backed by `/api/user/managed-profiles` and
+`/api/user/uploaded-documents`; results stream page-by-page through the
+existing rate-limited client.
 
 ## Documentation
 


### PR DESCRIPTION
README has been pinned to v0.16 and missing newer surface for a while. This brings it up to date with what shipped in:

- **v0.18.0** — list resources for `terraform query` discovery
- **v0.19.0** — `data \"geni_profile\"` source
- **v0.20.0** — `title` / `suffix` / `occupation` attributes

## Changes

- Version pin `~> 0.16` → `~> 0.20`.
- Fixes the `data \"geni_project\"` example which used `project_id = \"…\"` (the actual attribute is `id`). Copy-pasting the prior block failed with \"Unsupported argument\".
- Adds a `data \"geni_profile\"` example covering both `id` and `guid` lookup, with a note on merge-chain following.
- Adds a `## Discovery (Terraform 1.14+)` section showing the `list {}` blocks for profiles and documents.
- Surfaces `title` / `occupation` on the father example to make the new attributes discoverable.

No code or CHANGELOG change — README-only.