### PR TITLE
chore: bump Go to 1.26

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,4 +85,4 @@ Every PR that ships user-visible behavior **must** land these two artifacts in t
 
 ## Go Version
 
-Go 1.24.1 with vendored dependencies (`vendor/`).
+Go 1.26 with vendored dependencies (`vendor/`).

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dmalch/terraform-provider-genealogy
 
-go 1.25.8
+go 1.26
 
 require (
 	github.com/allegro/bigcache/v3 v3.1.0


### PR DESCRIPTION
## Summary

Bump the declared Go version from 1.25.8 to 1.26 so the module floor matches the toolchain in use. CI picks this up automatically — every workflow uses `go-version-file: 'go.mod'`.

Lands as a small, isolated PR before the upcoming `go-geni` library extraction, so the new repo can be born on a current Go version without any version-skew baggage.

## Changes

- `go.mod` line 3: `go 1.25.8` → `go 1.26`
- `CLAUDE.md` Go Version section: `1.24.1` → `1.26` (was already two minors stale)

`go mod tidy && go mod vendor` produced no diff — no indirect dep changes needed.

## Test plan

- [x] `go build ./...` clean.
- [x] `go test ./...` — unit suite green on the new toolchain.
- [x] `golangci-lint run` — 0 issues.
- [x] Sandbox smoke against three diverse acceptance tests (`TestAccProfile_createProfile`, `TestAccUnion_createUnionWithTwoPartners`, `TestAccDataSourceProfile_byID`) — all green.

Scheduled for v0.20.1 (no behavioural change; Go-version bump is user-visible only for source builds).