### PR TITLE
chore: gitignore .claude/ session state

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"d832552b-9d3d-4452-a393-6788ce362d4c","pid":70610,"procStart":"Sun May 10 21:06:03 2026","acquiredAt":1778510903175}

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ go.work.sum
 
 # Playwright MCP snapshots and console logs
 .playwright-mcp/
+
+# Claude Code session state (local task-runner scratch)
+.claude/


### PR DESCRIPTION
A `.claude/scheduled_tasks.lock` file slipped into the v0.21.0 merge. It's local task-runner scratch from the developer's session — harmless content, but doesn't belong in source control.

Adds `.claude/` to `.gitignore` and untracks the lock file. No code change, no behavioural change, no CHANGELOG entry needed (development-only).
