### PR TITLE
fix(union): clear collection fields that drain to empty on Read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.21.1 (Unreleased)
 
+BUG FIXES:
+
+* `geni_union`: `Read` (refresh) now clears `partners`, `children`, `foster_children`, and `adopted_children` when the collection has drained to empty on Geni. Previously an empty API list left the stale prior-state value in place, producing a permanent phantom diff on every `terraform plan` that only an otherwise no-op `apply` could clear. (#106)
+
 ## 0.21.0
 
 IMPROVEMENTS:

--- a/internal/resource/union/convert.go
+++ b/internal/resource/union/convert.go
@@ -25,37 +25,20 @@ func ValueFrom(ctx context.Context, union *geni.UnionResponse, unionModel *Resou
 		tagged[id] = struct{}{}
 	}
 
-	if len(union.Children) > 0 {
-		biological := make([]string, 0, len(union.Children))
-		for _, id := range union.Children {
-			if _, isTagged := tagged[id]; !isTagged {
-				biological = append(biological, id)
-			}
-		}
-		if len(biological) > 0 {
-			children, diags := types.SetValueFrom(ctx, types.StringType, biological)
-			d.Append(diags...)
-			unionModel.Children = children
+	// Assign every collection unconditionally so Read reflects collections
+	// that have drained to empty on Geni. Skipping the assignment for an
+	// empty API list would leave the stale prior-state value in place and
+	// produce a permanent phantom diff on every plan (issue #106).
+	biological := make([]string, 0, len(union.Children))
+	for _, id := range union.Children {
+		if _, isTagged := tagged[id]; !isTagged {
+			biological = append(biological, id)
 		}
 	}
-
-	if len(union.FosterChildren) > 0 {
-		foster, diags := types.SetValueFrom(ctx, types.StringType, union.FosterChildren)
-		d.Append(diags...)
-		unionModel.FosterChildren = foster
-	}
-
-	if len(union.AdoptedChildren) > 0 {
-		adopted, diags := types.SetValueFrom(ctx, types.StringType, union.AdoptedChildren)
-		d.Append(diags...)
-		unionModel.AdoptedChildren = adopted
-	}
-
-	if len(union.Partners) > 0 {
-		partners, diags := types.SetValueFrom(ctx, types.StringType, union.Partners)
-		d.Append(diags...)
-		unionModel.Partners = partners
-	}
+	unionModel.Children = setOrNull(ctx, biological, &d)
+	unionModel.FosterChildren = setOrNull(ctx, union.FosterChildren, &d)
+	unionModel.AdoptedChildren = setOrNull(ctx, union.AdoptedChildren, &d)
+	unionModel.Partners = setOrNull(ctx, union.Partners, &d)
 
 	marriage, diags := event.ValueFrom(ctx, union.Marriage)
 	d.Append(diags...)
@@ -162,6 +145,17 @@ func hashMapFrom(slice []string) map[string]struct{} {
 		hashMap[elem] = struct{}{}
 	}
 	return hashMap
+}
+
+// setOrNull builds a string Set from ids, or returns a typed null Set when ids
+// is empty so that Read reflects collections that drained to empty on Geni.
+func setOrNull(ctx context.Context, ids []string, d *diag.Diagnostics) types.Set {
+	if len(ids) == 0 {
+		return types.SetNull(types.StringType)
+	}
+	set, diags := types.SetValueFrom(ctx, types.StringType, ids)
+	d.Append(diags...)
+	return set
 }
 
 func convertToSlice(ctx context.Context, set types.Set) ([]string, diag.Diagnostics) {

--- a/internal/resource/union/convert_test.go
+++ b/internal/resource/union/convert_test.go
@@ -132,6 +132,85 @@ func TestValueFrom(t *testing.T) {
 		Expect(adopted).To(ConsistOf("profile-5"))
 	})
 
+	t.Run("Clears partners when the API returns no partners", func(t *testing.T) {
+		RegisterTestingT(t)
+		givenResponse := &geni.UnionResponse{
+			Id:       "union-drained",
+			Children: []string{"profile-3"},
+		}
+
+		model := &ResourceModel{
+			Children: types.SetNull(types.StringType),
+			Partners: types.SetValueMust(types.StringType, []attr.Value{types.StringValue("profile-1")}),
+		}
+		diags := ValueFrom(t.Context(), givenResponse, model)
+
+		Expect(diags.HasError()).To(BeFalse())
+		Expect(model.Partners.IsNull()).To(BeTrue())
+	})
+
+	t.Run("Clears adopted_children when the API returns no adopted children", func(t *testing.T) {
+		RegisterTestingT(t)
+		givenResponse := &geni.UnionResponse{
+			Id:       "union-drained",
+			Partners: []string{"profile-1"},
+		}
+
+		model := &ResourceModel{
+			Children:        types.SetNull(types.StringType),
+			FosterChildren:  types.SetNull(types.StringType),
+			AdoptedChildren: types.SetValueMust(types.StringType, []attr.Value{types.StringValue("profile-9")}),
+			Partners:        types.SetNull(types.StringType),
+		}
+		diags := ValueFrom(t.Context(), givenResponse, model)
+
+		Expect(diags.HasError()).To(BeFalse())
+		Expect(model.AdoptedChildren.IsNull()).To(BeTrue())
+	})
+
+	t.Run("Clears foster_children when the API returns no foster children", func(t *testing.T) {
+		RegisterTestingT(t)
+		givenResponse := &geni.UnionResponse{
+			Id:       "union-drained",
+			Partners: []string{"profile-1"},
+		}
+
+		model := &ResourceModel{
+			Children:        types.SetNull(types.StringType),
+			FosterChildren:  types.SetValueMust(types.StringType, []attr.Value{types.StringValue("profile-9")}),
+			AdoptedChildren: types.SetNull(types.StringType),
+			Partners:        types.SetNull(types.StringType),
+		}
+		diags := ValueFrom(t.Context(), givenResponse, model)
+
+		Expect(diags.HasError()).To(BeFalse())
+		Expect(model.FosterChildren.IsNull()).To(BeTrue())
+	})
+
+	t.Run("Clears children when all children become foster or adopted", func(t *testing.T) {
+		RegisterTestingT(t)
+		givenResponse := &geni.UnionResponse{
+			Id:             "union-drained",
+			Children:       []string{"profile-1"},
+			FosterChildren: []string{"profile-1"},
+		}
+
+		model := &ResourceModel{
+			Children:        types.SetValueMust(types.StringType, []attr.Value{types.StringValue("profile-1")}),
+			FosterChildren:  types.SetNull(types.StringType),
+			AdoptedChildren: types.SetNull(types.StringType),
+			Partners:        types.SetNull(types.StringType),
+		}
+		diags := ValueFrom(t.Context(), givenResponse, model)
+
+		Expect(diags.HasError()).To(BeFalse())
+		Expect(model.Children.IsNull()).To(BeTrue())
+
+		foster, d := convertToSlice(t.Context(), model.FosterChildren)
+		Expect(d.HasError()).To(BeFalse())
+		Expect(foster).To(ConsistOf("profile-1"))
+	})
+
 	t.Run("Leaves foster and adopted null when the response has no subsets", func(t *testing.T) {
 		RegisterTestingT(t)
 		givenResponse := &geni.UnionResponse{


### PR DESCRIPTION
## Summary

Fixes #106.

`geni_union` `Read` seeds state from prior state, then `ValueFrom` assigned each collection (`partners`, `children`, `foster_children`, `adopted_children`) **only when the API returned a non-empty list**. When a collection drained to empty on Geni (e.g. the last adopted child detached in the Geni web UI), the `if len(...) > 0` guard was false, the assignment was skipped, and the field kept its **stale prior-state value** — producing a permanent phantom diff (`adopted_children = ["profile-…"] -> null`) on every `terraform plan` that only an otherwise no-op `apply` could clear.

`children` had the defect twice: the outer `if len(union.Children) > 0` guard *and* the inner `if len(biological) > 0` post-filter — if every child became foster/adopted the biological bucket was never cleared.

## Fix

`internal/resource/union/convert.go` — `ValueFrom` now assigns all four collections **unconditionally** via a small `setOrNull` helper that returns a typed null `Set` (`types.SetNull(types.StringType)`) when the API list is empty, so refresh detects drain-to-empty drift. Null (not an empty set) preserves the null-vs-config distinction these `Optional` non-`Computed` attributes rely on.

## Tests

Four new sub-tests under `TestValueFrom` cover drain-to-empty for each collection, including the children inner-guard case (all children become foster/adopted). Existing tests stay green.

- `go test ./...` — full unit suite passes
- `golangci-lint run` — 0 issues

No schema change, so `make docs` is not required. CHANGELOG updated under `0.21.1 (Unreleased)`.