### PR TITLE
docs(readme): bump example version pin to ~> 0.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     geni = {
       source  = "dmalch/genealogy"
-      version = "~> 0.20"
+      version = "~> 0.21"
     }
   }
 }


### PR DESCRIPTION
Bumps the usage-example version constraint from `~> 0.20` to `~> 0.21` to track the current released minor (0.21.1). Documentation-only; no code change.