### PR TITLE
chore: deprecate use_profile_cache and use_document_cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ IMPROVEMENTS:
 
 * Upgrade the `github.com/dmalch/go-geni` dependency from `v0.1.0` to `v1.2.0`, its first stable release. Every Geni resource now lives in its own sub-package reached through a typed accessor on the client façade (e.g. `client.Profile().Get`, `client.Union().AddChild`), and the OAuth callback server swapped `labstack/echo` for the standard library — dropping four transitive dependencies. The provider was migrated to the new API surface; runtime behaviour for every resource, data source, schema, and acceptance test is unchanged. Relevant only to those building the provider from source.
 
+BEHAVIORAL CHANGES:
+
+* The `use_profile_cache` and `use_document_cache` provider attributes are deprecated; setting either now emits a deprecation warning. The provider's always-on batch client already coalesces reads, so the preload-everything cache is redundant — and slow for large managed sets (hence the long-standing `-target` caveat). The attributes still function unchanged for now and will be removed in a future release; remove them from your provider configuration. (#111)
+
 ## 0.21.1
 
 BUG FIXES:

--- a/README.md
+++ b/README.md
@@ -31,11 +31,14 @@ provider "geni" {
   attempt a browser-based OAuth flow to obtain one. Falls back to the `GENI_ACCESS_TOKEN` environment variable.
 * `use_sandbox_env`: (Optional) Use the Geni sandbox environment. Default is `false`. Falls back to the
   `GENI_USE_SANDBOX` environment variable (set to `true` to enable).
-* `use_profile_cache` (Optional) Whether to use the profile cache for faster lookups. It preloads all profiles managed
-  by the current user, which may be slow for those with many profiles. Not recommended for use with the `-target` flag.
-* `use_document_cache` (Optional) Whether to use the document cache for faster lookups. It preloads all documents
-  uploaded by the current user, which may be slow for those with many documents. Not recommended for use with the
-  `-target` flag.
+* `use_profile_cache` (Optional, **Deprecated**) Whether to use the profile cache for faster lookups. It preloads all
+  profiles managed by the current user, which may be slow for those with many profiles. Not recommended for use with the
+  `-target` flag. Superseded by the always-on batch client, which coalesces reads without the preload cost — this
+  attribute will be removed in a future release.
+* `use_document_cache` (Optional, **Deprecated**) Whether to use the document cache for faster lookups. It preloads all
+  documents uploaded by the current user, which may be slow for those with many documents. Not recommended for use with
+  the `-target` flag. Superseded by the always-on batch client, which coalesces reads without the preload cost — this
+  attribute will be removed in a future release.
 * `auto_update_merged_profiles` (Optional) When a managed profile has been merged into another on Geni, automatically
   refresh its id in state on the next read instead of failing.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,6 @@ This provider enables managing data on Geni.com through Terraform. It exposes co
 
 - `access_token` (String, Sensitive) The Access Token for the Geni API. Can also be set with the GENI_ACCESS_TOKEN environment variable. If not provided, the provider will attempt to do a browser-based OAuth login flow.
 - `auto_update_merged_profiles` (Boolean) Whether to automatically update merged profiles in the state
-- `use_document_cache` (Boolean) Whether to use the document cache for faster lookups
-- `use_profile_cache` (Boolean) Whether to use the profile cache for faster lookups
+- `use_document_cache` (Boolean, Deprecated) Whether to use the document cache for faster lookups. Deprecated: superseded by the always-on batch client; will be removed in a future release.
+- `use_profile_cache` (Boolean, Deprecated) Whether to use the profile cache for faster lookups. Deprecated: superseded by the always-on batch client; will be removed in a future release.
 - `use_sandbox_env` (Boolean) Whether to use the Geni Sandbox environment. Can also be set with the GENI_USE_SANDBOX environment variable.

--- a/internal/provider.go
+++ b/internal/provider.go
@@ -61,11 +61,15 @@ func (p *GeniProvider) Schema(_ context.Context, _ provider.SchemaRequest, resp 
 			},
 			"use_profile_cache": schema.BoolAttribute{
 				Optional:    true,
-				Description: "Whether to use the profile cache for faster lookups",
+				Description: "Whether to use the profile cache for faster lookups. Deprecated: superseded by the always-on batch client; will be removed in a future release.",
+				DeprecationMessage: "The provider's batch client already coalesces profile reads, so this cache offers no benefit and forces a slow preload of every managed profile. " +
+					"This attribute will be removed in a future release; remove it from your provider configuration.",
 			},
 			"use_document_cache": schema.BoolAttribute{
 				Optional:    true,
-				Description: "Whether to use the document cache for faster lookups",
+				Description: "Whether to use the document cache for faster lookups. Deprecated: superseded by the always-on batch client; will be removed in a future release.",
+				DeprecationMessage: "The provider's batch client already coalesces document reads, so this cache offers no benefit and forces a slow preload of every uploaded document. " +
+					"This attribute will be removed in a future release; remove it from your provider configuration.",
 			},
 			"auto_update_merged_profiles": schema.BoolAttribute{
 				Optional:    true,


### PR DESCRIPTION
## Summary

Phase 1 of cleaning up the obsolete cache config flags: **deprecate `use_profile_cache` and `use_document_cache`** (non-breaking).

## Why

Both flags toggle the `genicache` layer, which preloads *every* managed profile / uploaded document (`cache_client.go` paginates up to ~10k entries, ~3 min at the rate limit) before serving the first read.

The always-on `genibatch` client already coalesces Terraform's concurrent refresh reads into bulk requests (≤50 IDs, deduplicated). Terraform reads each managed resource once per refresh, so the cache trades "N bulk fetches" for "ALL bulk fetches + memory reads" — strictly worse unless your config covers nearly your entire managed set. The README already flagged it as slow and "Not recommended for use with the `-target` flag", and a cache miss falls back to the batch client anyway.

## Changes

- `provider.go` — `DeprecationMessage` on both `schema.BoolAttribute`s, so Terraform emits a warning when either is set. **Both flags still function unchanged.**
- `README.md` — both config bullets marked **Deprecated**.
- `docs/index.md` — regenerated (`make docs`); attributes now render `(Boolean, Deprecated)`.
- `CHANGELOG.md` — `BEHAVIORAL CHANGES` entry under `0.21.2 (Unreleased)`.

## Follow-up (Phase 2, separate PR, later release)

Remove the attributes, delete the `internal/genicache` package, drop the `github.com/allegro/bigcache/v3` dependency, and collapse `getProfile`/`getDocument` to a plain batch-client call.

## Verification

- `go build ./...` — pass
- `golangci-lint run` — 0 issues
- `make docs` — committed, in sync