### PR TITLE
refactor: extract duplicated set helpers into internal/tfset

### DIFF
--- a/internal/resource/document/convert.go
+++ b/internal/resource/document/convert.go
@@ -9,6 +9,7 @@ import (
 
 	genidocument "github.com/dmalch/go-geni/document"
 	"github.com/dmalch/terraform-provider-genealogy/internal/resource/event"
+	"github.com/dmalch/terraform-provider-genealogy/internal/tfset"
 )
 
 func ValueFrom(ctx context.Context, response *genidocument.Document, model *ResourceModel) diag.Diagnostics {
@@ -50,7 +51,7 @@ func RequestFrom(ctx context.Context, resourceModel ResourceModel) (*genidocumen
 	locationModel, diags := event.LocationObjectValueFrom(ctx, resourceModel.Location)
 	d.Append(diags...)
 
-	labelModels, diags := convertToSlice(ctx, resourceModel.Labels)
+	labelModels, diags := tfset.Strings(ctx, resourceModel.Labels)
 	d.Append(diags...)
 
 	var labels *string
@@ -74,25 +75,6 @@ func RequestFrom(ctx context.Context, resourceModel ResourceModel) (*genidocumen
 	}
 
 	return documentRequest, d
-}
-
-func convertToSlice(ctx context.Context, set types.Set) ([]string, diag.Diagnostics) {
-	if len(set.Elements()) == 0 {
-		return nil, diag.Diagnostics{}
-	}
-
-	var slice = make([]string, len(set.Elements()))
-	diags := set.ElementsAs(ctx, &slice, false)
-
-	return slice, diags
-}
-
-func hashMapFrom(slice []string) map[string]struct{} {
-	hashMap := make(map[string]struct{}, len(slice))
-	for _, elem := range slice {
-		hashMap[elem] = struct{}{}
-	}
-	return hashMap
 }
 
 func UpdateComputedFields(ctx context.Context, response *genidocument.Document, resourceModel *ResourceModel) diag.Diagnostics {

--- a/internal/resource/document/create.go
+++ b/internal/resource/document/create.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+
+	"github.com/dmalch/terraform-provider-genealogy/internal/tfset"
 )
 
 // Create creates the resource.
@@ -15,13 +17,13 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 	}
 
 	// Get the planned profiles to tag the document with
-	profileIds, diags := convertToSlice(ctx, plan.Profiles)
+	profileIds, diags := tfset.Strings(ctx, plan.Profiles)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	projectIds, diags := convertToSlice(ctx, plan.Projects)
+	projectIds, diags := tfset.Strings(ctx, plan.Projects)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/resource/document/update.go
+++ b/internal/resource/document/update.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/dmalch/terraform-provider-genealogy/internal/tfset"
 )
 
 // Update updates the resource.
@@ -31,7 +33,7 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		return
 	}
 
-	projectIds, diags := convertToSlice(ctx, plan.Projects)
+	projectIds, diags := tfset.Strings(ctx, plan.Projects)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -51,19 +53,19 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 
 	// Check if profile IDs have changed
 	if !state.Profiles.Equal(plan.Profiles) {
-		planProfileIds, diags := convertToSlice(ctx, plan.Profiles)
+		planProfileIds, diags := tfset.Strings(ctx, plan.Profiles)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
 			return
 		}
-		knownPlanProfileIds := hashMapFrom(planProfileIds)
+		knownPlanProfileIds := tfset.Index(planProfileIds)
 
-		stateProfileIds, diags := convertToSlice(ctx, state.Profiles)
+		stateProfileIds, diags := tfset.Strings(ctx, state.Profiles)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
 			return
 		}
-		knownStateProfileIds := hashMapFrom(stateProfileIds)
+		knownStateProfileIds := tfset.Index(stateProfileIds)
 
 		// Untag profiles that are no longer associated with the document
 		for profileId := range knownStateProfileIds {

--- a/internal/resource/profile/convert.go
+++ b/internal/resource/profile/convert.go
@@ -10,6 +10,7 @@ import (
 
 	geniprofile "github.com/dmalch/go-geni/profile"
 	"github.com/dmalch/terraform-provider-genealogy/internal/resource/event"
+	"github.com/dmalch/terraform-provider-genealogy/internal/tfset"
 )
 
 func ValueFrom(ctx context.Context, profile *geniprofile.Profile, profileModel *ResourceModel) diag.Diagnostics {
@@ -237,7 +238,7 @@ func NameElementsFrom(ctx context.Context, names types.Map) (map[string]geniprof
 	var profileNames = make(map[string]geniprofile.NameElement, len(nameModels))
 
 	for locale, nameModel := range nameModels {
-		nicknamesSlice, d := convertToSlice(ctx, nameModel.Nicknames)
+		nicknamesSlice, d := tfset.Strings(ctx, nameModel.Nicknames)
 		diags = append(diags, d...)
 		nicknamesCsv := strings.Join(nicknamesSlice, ",")
 
@@ -329,15 +330,4 @@ func optionalString(s string) types.String {
 		return types.StringNull()
 	}
 	return types.StringValue(s)
-}
-
-func convertToSlice(ctx context.Context, set types.Set) ([]string, diag.Diagnostics) {
-	if len(set.Elements()) == 0 {
-		return nil, diag.Diagnostics{}
-	}
-
-	var slice = make([]string, len(set.Elements()))
-	diags := set.ElementsAs(ctx, &slice, false)
-
-	return slice, diags
 }

--- a/internal/resource/profile/create.go
+++ b/internal/resource/profile/create.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/dmalch/terraform-provider-genealogy/internal/tfset"
 )
 
 // Create creates the resource.
@@ -21,7 +23,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		return
 	}
 
-	projectIds, diags := convertToSlice(ctx, plan.Projects)
+	projectIds, diags := tfset.Strings(ctx, plan.Projects)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/resource/profile/update.go
+++ b/internal/resource/profile/update.go
@@ -8,6 +8,7 @@ import (
 
 	geniprofile "github.com/dmalch/go-geni/profile"
 	"github.com/dmalch/terraform-provider-genealogy/internal/resource/event"
+	"github.com/dmalch/terraform-provider-genealogy/internal/tfset"
 )
 
 // Update updates the resource.
@@ -43,7 +44,7 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		}
 	}
 
-	projectIds, diags := convertToSlice(ctx, plan.Projects)
+	projectIds, diags := tfset.Strings(ctx, plan.Projects)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/resource/union/convert.go
+++ b/internal/resource/union/convert.go
@@ -8,6 +8,7 @@ import (
 
 	geniunion "github.com/dmalch/go-geni/union"
 	"github.com/dmalch/terraform-provider-genealogy/internal/resource/event"
+	"github.com/dmalch/terraform-provider-genealogy/internal/tfset"
 )
 
 func ValueFrom(ctx context.Context, union *geniunion.Union, unionModel *ResourceModel) diag.Diagnostics {
@@ -115,7 +116,7 @@ func childrenWithChangedModifier(ctx context.Context, plan, state ResourceModel)
 func labelsFor(ctx context.Context, m ResourceModel) map[string]string {
 	labels := make(map[string]string)
 	add := func(set types.Set, label string) {
-		ids, _ := convertToSlice(ctx, set)
+		ids, _ := tfset.Strings(ctx, set)
 		for _, id := range ids {
 			labels[id] = label
 		}
@@ -139,14 +140,6 @@ func modifierFor(childId string, fosterChildren, adoptedChildren map[string]stru
 	return ""
 }
 
-func hashMapFrom(slice []string) map[string]struct{} {
-	hashMap := make(map[string]struct{}, len(slice))
-	for _, elem := range slice {
-		hashMap[elem] = struct{}{}
-	}
-	return hashMap
-}
-
 // setOrNull builds a string Set from ids, or returns a typed null Set when ids
 // is empty so that Read reflects collections that drained to empty on Geni.
 func setOrNull(ctx context.Context, ids []string, d *diag.Diagnostics) types.Set {
@@ -156,10 +149,4 @@ func setOrNull(ctx context.Context, ids []string, d *diag.Diagnostics) types.Set
 	set, diags := types.SetValueFrom(ctx, types.StringType, ids)
 	d.Append(diags...)
 	return set
-}
-
-func convertToSlice(ctx context.Context, set types.Set) ([]string, diag.Diagnostics) {
-	slice := make([]string, 0, len(set.Elements()))
-	diags := set.ElementsAs(ctx, &slice, false)
-	return slice, diags
 }

--- a/internal/resource/union/convert_test.go
+++ b/internal/resource/union/convert_test.go
@@ -10,6 +10,7 @@ import (
 	geniprofile "github.com/dmalch/go-geni/profile"
 	geniunion "github.com/dmalch/go-geni/union"
 	"github.com/dmalch/terraform-provider-genealogy/internal/resource/event"
+	"github.com/dmalch/terraform-provider-genealogy/internal/tfset"
 )
 
 func ptr[T any](s T) *T {
@@ -120,15 +121,15 @@ func TestValueFrom(t *testing.T) {
 
 		Expect(diags.HasError()).To(BeFalse())
 
-		bio, d := convertToSlice(t.Context(), model.Children)
+		bio, d := tfset.Strings(t.Context(), model.Children)
 		Expect(d.HasError()).To(BeFalse())
 		Expect(bio).To(ConsistOf("profile-3", "profile-6"))
 
-		foster, d := convertToSlice(t.Context(), model.FosterChildren)
+		foster, d := tfset.Strings(t.Context(), model.FosterChildren)
 		Expect(d.HasError()).To(BeFalse())
 		Expect(foster).To(ConsistOf("profile-4"))
 
-		adopted, d := convertToSlice(t.Context(), model.AdoptedChildren)
+		adopted, d := tfset.Strings(t.Context(), model.AdoptedChildren)
 		Expect(d.HasError()).To(BeFalse())
 		Expect(adopted).To(ConsistOf("profile-5"))
 	})
@@ -207,7 +208,7 @@ func TestValueFrom(t *testing.T) {
 		Expect(diags.HasError()).To(BeFalse())
 		Expect(model.Children.IsNull()).To(BeTrue())
 
-		foster, d := convertToSlice(t.Context(), model.FosterChildren)
+		foster, d := tfset.Strings(t.Context(), model.FosterChildren)
 		Expect(d.HasError()).To(BeFalse())
 		Expect(foster).To(ConsistOf("profile-1"))
 	})
@@ -355,32 +356,6 @@ func TestRequestFrom(t *testing.T) {
 	})
 }
 
-func TestHashMapFrom(t *testing.T) {
-	t.Run("Creates a hash map from a slice", func(t *testing.T) {
-		RegisterTestingT(t)
-		result := hashMapFrom([]string{"a", "b", "c"})
-
-		Expect(result).To(HaveLen(3))
-		Expect(result).To(HaveKey("a"))
-		Expect(result).To(HaveKey("b"))
-		Expect(result).To(HaveKey("c"))
-	})
-
-	t.Run("Deduplicates entries", func(t *testing.T) {
-		RegisterTestingT(t)
-		result := hashMapFrom([]string{"a", "a", "b"})
-
-		Expect(result).To(HaveLen(2))
-	})
-
-	t.Run("Returns empty map for empty slice", func(t *testing.T) {
-		RegisterTestingT(t)
-		result := hashMapFrom([]string{})
-
-		Expect(result).To(BeEmpty())
-	})
-}
-
 func TestModifierFor(t *testing.T) {
 	RegisterTestingT(t)
 	plan := ResourceModel{
@@ -389,13 +364,13 @@ func TestModifierFor(t *testing.T) {
 		AdoptedChildren: types.SetValueMust(types.StringType, []attr.Value{types.StringValue("adopted-1")}),
 	}
 
-	foster, err := convertToSlice(t.Context(), plan.FosterChildren)
+	foster, err := tfset.Strings(t.Context(), plan.FosterChildren)
 	Expect(err.HasError()).To(BeFalse())
-	adopted, err := convertToSlice(t.Context(), plan.AdoptedChildren)
+	adopted, err := tfset.Strings(t.Context(), plan.AdoptedChildren)
 	Expect(err.HasError()).To(BeFalse())
 
-	fosterSet := hashMapFrom(foster)
-	adoptedSet := hashMapFrom(adopted)
+	fosterSet := tfset.Index(foster)
+	adoptedSet := tfset.Index(adopted)
 
 	Expect(modifierFor("foster-1", fosterSet, adoptedSet)).To(Equal("foster"))
 	Expect(modifierFor("adopted-1", fosterSet, adoptedSet)).To(Equal("adopt"))
@@ -465,32 +440,5 @@ func TestChildrenWithChangedModifier(t *testing.T) {
 			AdoptedChildren: types.SetNull(types.StringType),
 		}
 		Expect(childrenWithChangedModifier(t.Context(), plan, state)).To(BeEmpty())
-	})
-}
-
-func TestConvertToSlice(t *testing.T) {
-	t.Run("Converts a set to a slice", func(t *testing.T) {
-		RegisterTestingT(t)
-		set := types.SetValueMust(types.StringType, []attr.Value{
-			types.StringValue("a"),
-			types.StringValue("b"),
-			types.StringValue("c"),
-		})
-
-		result, diags := convertToSlice(t.Context(), set)
-
-		Expect(diags.HasError()).To(BeFalse())
-		Expect(result).To(HaveLen(3))
-		Expect(result).To(ContainElements("a", "b", "c"))
-	})
-
-	t.Run("Returns empty slice for empty set", func(t *testing.T) {
-		RegisterTestingT(t)
-		set := types.SetValueMust(types.StringType, []attr.Value{})
-
-		result, diags := convertToSlice(t.Context(), set)
-
-		Expect(diags.HasError()).To(BeFalse())
-		Expect(result).To(BeEmpty())
 	})
 }

--- a/internal/resource/union/create.go
+++ b/internal/resource/union/create.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	geniprofile "github.com/dmalch/go-geni/profile"
+	"github.com/dmalch/terraform-provider-genealogy/internal/tfset"
 )
 
 // Create creates the resource.
@@ -18,7 +19,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		return
 	}
 
-	partnerIds, diags := convertToSlice(ctx, plan.Partners)
+	partnerIds, diags := tfset.Strings(ctx, plan.Partners)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -48,17 +49,17 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 	// Set the children. If the union already exists and has children, we can set
 	// them by calling the union/add-child API. If not, we can use profile/add-child
 	// on a parent profile.
-	childrenIds, diags := convertToSlice(ctx, plan.Children)
+	childrenIds, diags := tfset.Strings(ctx, plan.Children)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	fosterIds, diags := convertToSlice(ctx, plan.FosterChildren)
+	fosterIds, diags := tfset.Strings(ctx, plan.FosterChildren)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	adoptedIds, diags := convertToSlice(ctx, plan.AdoptedChildren)
+	adoptedIds, diags := tfset.Strings(ctx, plan.AdoptedChildren)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -69,8 +70,8 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 	allChildrenIds = append(allChildrenIds, fosterIds...)
 	allChildrenIds = append(allChildrenIds, adoptedIds...)
 
-	fosterSet := hashMapFrom(fosterIds)
-	adoptedSet := hashMapFrom(adoptedIds)
+	fosterSet := tfset.Index(fosterIds)
+	adoptedSet := tfset.Index(adoptedIds)
 
 	if len(allChildrenIds) > 0 {
 		var skipNextIteration bool

--- a/internal/resource/union/read.go
+++ b/internal/resource/union/read.go
@@ -13,6 +13,7 @@ import (
 	"github.com/dmalch/go-geni"
 	geniprofile "github.com/dmalch/go-geni/profile"
 	geniunion "github.com/dmalch/go-geni/union"
+	"github.com/dmalch/terraform-provider-genealogy/internal/tfset"
 )
 
 // Read reads the resource.
@@ -84,7 +85,7 @@ func (r *Resource) findExistingUnionForPartners(ctx context.Context, partners ty
 	var diags diag.Diagnostics
 
 	// Attempt to find an existing union for partners in the state
-	partnerIds, diags := convertToSlice(ctx, partners)
+	partnerIds, diags := tfset.Strings(ctx, partners)
 	if diags.HasError() {
 		return "", diags
 	}

--- a/internal/resource/union/update.go
+++ b/internal/resource/union/update.go
@@ -8,6 +8,7 @@ import (
 
 	geniprofile "github.com/dmalch/go-geni/profile"
 	"github.com/dmalch/terraform-provider-genealogy/internal/resource/event"
+	"github.com/dmalch/terraform-provider-genealogy/internal/tfset"
 )
 
 // Update updates the resource.
@@ -32,19 +33,19 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 
 	// Check if parents were updated
 	if !plan.Partners.Equal(state.Partners) {
-		planPartnerIds, diags := convertToSlice(ctx, plan.Partners)
+		planPartnerIds, diags := tfset.Strings(ctx, plan.Partners)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
 			return
 		}
-		knownPlanPartnerIds := hashMapFrom(planPartnerIds)
+		knownPlanPartnerIds := tfset.Index(planPartnerIds)
 
-		statePartnerIds, diags := convertToSlice(ctx, state.Partners)
+		statePartnerIds, diags := tfset.Strings(ctx, state.Partners)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
 			return
 		}
-		knownStatePartnerIds := hashMapFrom(statePartnerIds)
+		knownStatePartnerIds := tfset.Index(statePartnerIds)
 
 		for _, partnerId := range statePartnerIds {
 			// If the partner is not in the plan, fail the update because we can't remove
@@ -90,33 +91,33 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		!plan.FosterChildren.Equal(state.FosterChildren) ||
 		!plan.AdoptedChildren.Equal(state.AdoptedChildren) {
 
-		planBio, diags := convertToSlice(ctx, plan.Children)
+		planBio, diags := tfset.Strings(ctx, plan.Children)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
 			return
 		}
-		planFoster, diags := convertToSlice(ctx, plan.FosterChildren)
+		planFoster, diags := tfset.Strings(ctx, plan.FosterChildren)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
 			return
 		}
-		planAdopted, diags := convertToSlice(ctx, plan.AdoptedChildren)
+		planAdopted, diags := tfset.Strings(ctx, plan.AdoptedChildren)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
 			return
 		}
 
-		stateBio, diags := convertToSlice(ctx, state.Children)
+		stateBio, diags := tfset.Strings(ctx, state.Children)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
 			return
 		}
-		stateFoster, diags := convertToSlice(ctx, state.FosterChildren)
+		stateFoster, diags := tfset.Strings(ctx, state.FosterChildren)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
 			return
 		}
-		stateAdopted, diags := convertToSlice(ctx, state.AdoptedChildren)
+		stateAdopted, diags := tfset.Strings(ctx, state.AdoptedChildren)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
 			return
@@ -125,8 +126,8 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		planAll := append(append(append([]string{}, planBio...), planFoster...), planAdopted...)
 		stateAll := append(append(append([]string{}, stateBio...), stateFoster...), stateAdopted...)
 
-		knownPlanAll := hashMapFrom(planAll)
-		knownStateAll := hashMapFrom(stateAll)
+		knownPlanAll := tfset.Index(planAll)
+		knownStateAll := tfset.Index(stateAll)
 
 		for _, childId := range stateAll {
 			// If the child is not in the plan, fail the update because we can't remove
@@ -136,8 +137,8 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 			}
 		}
 
-		fosterSet := hashMapFrom(planFoster)
-		adoptedSet := hashMapFrom(planAdopted)
+		fosterSet := tfset.Index(planFoster)
+		adoptedSet := tfset.Index(planAdopted)
 
 		for _, childId := range planAll {
 			// If the child is not in the state, we need to add it

--- a/internal/tfset/tfset.go
+++ b/internal/tfset/tfset.go
@@ -1,0 +1,33 @@
+// Package tfset converts Terraform Plugin Framework set values into the plain
+// Go collections used by the resource conversion code, and builds membership
+// indexes over those values.
+package tfset
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// Strings returns the elements of a Terraform string set as a slice. A null or
+// empty set yields a non-nil, empty slice and no diagnostics.
+func Strings(ctx context.Context, set types.Set) ([]string, diag.Diagnostics) {
+	if len(set.Elements()) == 0 {
+		return []string{}, nil
+	}
+
+	slice := make([]string, 0, len(set.Elements()))
+	diags := set.ElementsAs(ctx, &slice, false)
+	return slice, diags
+}
+
+// Index builds a membership set over values for O(1) lookups. Duplicate values
+// collapse into a single entry.
+func Index(values []string) map[string]struct{} {
+	index := make(map[string]struct{}, len(values))
+	for _, v := range values {
+		index[v] = struct{}{}
+	}
+	return index
+}

--- a/internal/tfset/tfset_test.go
+++ b/internal/tfset/tfset_test.go
@@ -1,0 +1,70 @@
+package tfset
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	. "github.com/onsi/gomega"
+)
+
+func TestStrings(t *testing.T) {
+	t.Run("Returns the elements of a populated set", func(t *testing.T) {
+		RegisterTestingT(t)
+		set := types.SetValueMust(types.StringType, []attr.Value{
+			types.StringValue("a"),
+			types.StringValue("b"),
+			types.StringValue("c"),
+		})
+
+		result, diags := Strings(t.Context(), set)
+
+		Expect(diags.HasError()).To(BeFalse())
+		Expect(result).To(ConsistOf("a", "b", "c"))
+	})
+
+	t.Run("Returns a non-nil empty slice for an empty set", func(t *testing.T) {
+		RegisterTestingT(t)
+		set := types.SetValueMust(types.StringType, []attr.Value{})
+
+		result, diags := Strings(t.Context(), set)
+
+		Expect(diags.HasError()).To(BeFalse())
+		Expect(result).ToNot(BeNil())
+		Expect(result).To(BeEmpty())
+	})
+
+	t.Run("Returns a non-nil empty slice for a null set", func(t *testing.T) {
+		RegisterTestingT(t)
+		result, diags := Strings(t.Context(), types.SetNull(types.StringType))
+
+		Expect(diags.HasError()).To(BeFalse())
+		Expect(result).ToNot(BeNil())
+		Expect(result).To(BeEmpty())
+	})
+}
+
+func TestIndex(t *testing.T) {
+	t.Run("Indexes every value for membership lookup", func(t *testing.T) {
+		RegisterTestingT(t)
+		result := Index([]string{"a", "b", "c"})
+
+		Expect(result).To(HaveLen(3))
+		Expect(result).To(HaveKey("a"))
+		Expect(result).To(HaveKey("b"))
+		Expect(result).To(HaveKey("c"))
+	})
+
+	t.Run("Collapses duplicate values", func(t *testing.T) {
+		RegisterTestingT(t)
+		result := Index([]string{"a", "a", "b"})
+
+		Expect(result).To(HaveLen(2))
+	})
+
+	t.Run("Returns an empty index for an empty slice", func(t *testing.T) {
+		RegisterTestingT(t)
+		Expect(Index(nil)).To(BeEmpty())
+		Expect(Index([]string{})).To(BeEmpty())
+	})
+}


### PR DESCRIPTION
## Summary

Removes the `convertToSlice` / `hashMapFrom` duplication flagged in the codebase review.

`convertToSlice` was copy-pasted across the `profile`, `union`, and `document` resource packages (3 copies); `hashMapFrom` across `union` and `document` (2 copies). The two `convertToSlice` copies had also quietly **drifted** — the `document`/`profile` copy short-circuited an empty set to a `nil` slice, the `union` copy returned an empty slice.

## Changes

New `internal/tfset` package with one implementation of each:

- **`tfset.Strings(ctx, set)`** — the elements of a Terraform string set as a `[]string`. A null or empty set yields a non-nil, empty slice (and no diagnostics).
- **`tfset.Index(values)`** — a `map[string]struct{}` membership set for O(1) lookups.

All ~30 call sites across the three resource packages now use these. The unit tests move into `internal/tfset/tfset_test.go`.

## Behaviour

No behaviour change for callers. The only observable difference is that `document`/`profile` callers now get a non-nil empty slice (instead of `nil`) for an empty set — and every call site treats `nil` and an empty slice identically (`range` / `len` / `Index`), so converging on the union package's non-nil behaviour is inert.

## Verification

- `go build ./...` / `make build` — pass
- `make test` — pass, including the new `internal/tfset` package tests
- `golangci-lint run` — 0 issues

No CHANGELOG/docs change — this is an internal-only refactor with no user-visible behaviour or schema change.