### PR TITLE
refactor: rename misnamed documentResponse to projectResponse

### DIFF
--- a/internal/datasource/project/read.go
+++ b/internal/datasource/project/read.go
@@ -17,7 +17,7 @@ func (d *DataSource) Read(ctx context.Context, req datasource.ReadRequest, resp 
 		return
 	}
 
-	documentResponse, err := d.client.Project().Get(ctx, data.ID.ValueString())
+	projectResponse, err := d.client.Project().Get(ctx, data.ID.ValueString())
 	if err != nil {
 		if errors.Is(err, geni.ErrResourceNotFound) {
 			resp.Diagnostics.AddWarning("Project not found", "The project was not found in the Geni API.")
@@ -29,7 +29,7 @@ func (d *DataSource) Read(ctx context.Context, req datasource.ReadRequest, resp 
 		return
 	}
 
-	diags := ValueFrom(ctx, documentResponse, &data)
+	diags := ValueFrom(ctx, projectResponse, &data)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return


### PR DESCRIPTION
Fixes the variable-naming bug flagged in the codebase review: the project data source's `Read` held a `*project.Project` in a variable named `documentResponse`.

Pure local-variable rename in `internal/datasource/project/read.go` — no behaviour change, no API/schema change. `go build`, `go vet`, and the package tests pass.

No CHANGELOG/docs change (internal-only, not user-visible).