### PR TITLE
refactor: move provider state from package globals onto the instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.21.5 (Unreleased)
 
+IMPROVEMENTS:
+
+* Internal refactor: the provider's API clients and one-time init guard move from package-level globals onto the `GeniProvider` instance, so each provider instance is self-contained and `Configure` is unit-testable. No behavioural change. Relevant only to those building the provider from source. (#115)
+
 ## 0.21.4
 
 IMPROVEMENTS:

--- a/internal/datasource/project/read.go
+++ b/internal/datasource/project/read.go
@@ -17,7 +17,7 @@ func (d *DataSource) Read(ctx context.Context, req datasource.ReadRequest, resp 
 		return
 	}
 
-	documentResponse, err := d.client.Project().Get(ctx, data.ID.ValueString())
+	projectResponse, err := d.client.Project().Get(ctx, data.ID.ValueString())
 	if err != nil {
 		if errors.Is(err, geni.ErrResourceNotFound) {
 			resp.Diagnostics.AddWarning("Project not found", "The project was not found in the Geni API.")
@@ -29,7 +29,7 @@ func (d *DataSource) Read(ctx context.Context, req datasource.ReadRequest, resp 
 		return
 	}
 
-	diags := ValueFrom(ctx, documentResponse, &data)
+	diags := ValueFrom(ctx, projectResponse, &data)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider.go
+++ b/internal/provider.go
@@ -28,16 +28,18 @@ import (
 
 var _ provider.ProviderWithListResources = (*GeniProvider)(nil)
 
+// GeniProvider holds the configured API clients. State lives on the instance
+// (not in package globals) so each provider is self-contained: every
+// GeniProvider.New() is independent, and Configure is unit-testable.
 type GeniProvider struct {
+	// once guards one-time creation of the clients and batch-processor
+	// goroutines; Configure may be invoked more than once on an instance.
+	once        sync.Once
+	initErr     error
+	client      *geni.Client
+	batchClient *genibatch.Client
+	cacheClient *genicache.Client
 }
-
-var (
-	initClientOnce = sync.Once{}
-	initClientErr  error
-	client         *geni.Client
-	batchClient    *genibatch.Client
-	cacheClient    *genicache.Client
-)
 
 func New() provider.Provider {
 	return &GeniProvider{}
@@ -119,42 +121,42 @@ func (p *GeniProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 		tokenSource = oauth2.StaticTokenSource(&oauth2.Token{AccessToken: accessToken})
 	}
 
-	initClientOnce.Do(func() {
-		client = geni.NewClient(tokenSource, useSandboxEnv)
-		batchClient = genibatch.NewClient(client)
-		cacheClient, initClientErr = genicache.NewClient(client, batchClient)
-		if initClientErr != nil {
+	p.once.Do(func() {
+		p.client = geni.NewClient(tokenSource, useSandboxEnv)
+		p.batchClient = genibatch.NewClient(p.client)
+		p.cacheClient, p.initErr = genicache.NewClient(p.client, p.batchClient)
+		if p.initErr != nil {
 			return
 		}
-		go batchClient.UnionBulkProcessor(context.Background())
-		go batchClient.ProfileBulkProcessor(context.Background())
-		go batchClient.DocumentBulkProcessor(context.Background())
+		go p.batchClient.UnionBulkProcessor(context.Background())
+		go p.batchClient.ProfileBulkProcessor(context.Background())
+		go p.batchClient.DocumentBulkProcessor(context.Background())
 	})
 
-	if initClientErr != nil {
-		resp.Diagnostics.AddError("error initializing cache client", initClientErr.Error())
+	if p.initErr != nil {
+		resp.Diagnostics.AddError("error initializing cache client", p.initErr.Error())
 		return
 	}
 
 	resp.ResourceData = &config.ClientData{
-		Client:                   client,
-		BatchClient:              batchClient,
-		CacheClient:              cacheClient,
+		Client:                   p.client,
+		BatchClient:              p.batchClient,
+		CacheClient:              p.cacheClient,
 		UseProfileCache:          cfg.UseProfileCache.ValueBool(),
 		UseDocumentCache:         cfg.UseDocumentCache.ValueBool(),
 		AutoUpdateMergedProfiles: cfg.AutoUpdateMergedProfiles.ValueBool(),
 	}
 
 	resp.DataSourceData = &config.ClientData{
-		Client:                   client,
-		BatchClient:              batchClient,
-		CacheClient:              cacheClient,
+		Client:                   p.client,
+		BatchClient:              p.batchClient,
+		CacheClient:              p.cacheClient,
 		UseProfileCache:          cfg.UseProfileCache.ValueBool(),
 		AutoUpdateMergedProfiles: cfg.AutoUpdateMergedProfiles.ValueBool(),
 	}
 
 	resp.ListResourceData = &config.ClientData{
-		Client: client,
+		Client: p.client,
 	}
 }
 

--- a/internal/provider_test.go
+++ b/internal/provider_test.go
@@ -5,7 +5,12 @@ import (
 	"path"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	. "github.com/onsi/gomega"
+
+	"github.com/dmalch/terraform-provider-genealogy/internal/config"
 )
 
 func TestTokenCacheFilePath(t *testing.T) {
@@ -45,4 +50,71 @@ func TestClientId(t *testing.T) {
 
 		Expect(clientId(true)).To(Equal("8"))
 	})
+}
+
+func TestConfigure(t *testing.T) {
+	t.Run("populates client data when a static access token is provided", func(t *testing.T) {
+		RegisterTestingT(t)
+		p := newProvider(t)
+
+		resp := configureProvider(t, p, "test-token")
+
+		Expect(resp.Diagnostics.HasError()).To(BeFalse())
+		Expect(p.client).ToNot(BeNil())
+		Expect(p.batchClient).ToNot(BeNil())
+
+		data, ok := resp.ResourceData.(*config.ClientData)
+		Expect(ok).To(BeTrue())
+		Expect(data.Client).To(BeIdenticalTo(p.client))
+		Expect(data.BatchClient).To(BeIdenticalTo(p.batchClient))
+	})
+
+	t.Run("separate provider instances get independent clients", func(t *testing.T) {
+		RegisterTestingT(t)
+		p1 := newProvider(t)
+		p2 := newProvider(t)
+
+		Expect(configureProvider(t, p1, "token-1").Diagnostics.HasError()).To(BeFalse())
+		Expect(configureProvider(t, p2, "token-2").Diagnostics.HasError()).To(BeFalse())
+
+		Expect(p1.client).ToNot(BeNil())
+		Expect(p2.client).ToNot(BeNil())
+		Expect(p1.client).ToNot(BeIdenticalTo(p2.client))
+	})
+}
+
+// newProvider returns a fresh *GeniProvider, failing the test if New ever
+// returns a different concrete type.
+func newProvider(t *testing.T) *GeniProvider {
+	t.Helper()
+	p, ok := New().(*GeniProvider)
+	if !ok {
+		t.Fatal("New() did not return a *GeniProvider")
+	}
+	return p
+}
+
+// configureProvider drives p.Configure with a provider config carrying only the
+// given access token (every other attribute null), so the run stays offline:
+// a static token skips the OAuth flow entirely.
+func configureProvider(t *testing.T, p *GeniProvider, accessToken string) *provider.ConfigureResponse {
+	t.Helper()
+	ctx := t.Context()
+
+	var schemaResp provider.SchemaResponse
+	p.Schema(ctx, provider.SchemaRequest{}, &schemaResp)
+
+	raw := tftypes.NewValue(schemaResp.Schema.Type().TerraformType(ctx), map[string]tftypes.Value{
+		"access_token":                tftypes.NewValue(tftypes.String, accessToken),
+		"use_sandbox_env":             tftypes.NewValue(tftypes.Bool, nil),
+		"use_profile_cache":           tftypes.NewValue(tftypes.Bool, nil),
+		"use_document_cache":          tftypes.NewValue(tftypes.Bool, nil),
+		"auto_update_merged_profiles": tftypes.NewValue(tftypes.Bool, nil),
+	})
+
+	resp := &provider.ConfigureResponse{}
+	p.Configure(ctx, provider.ConfigureRequest{
+		Config: tfsdk.Config{Schema: schemaResp.Schema, Raw: raw},
+	}, resp)
+	return resp
 }


### PR DESCRIPTION
## Summary

Resolves the "global mutable state in `provider.go`" item from the codebase review.

The client, batch client, cache client, init error, and the one-time init guard lived as **package-level vars**; `GeniProvider` itself was an empty struct.

## Why it mattered

It worked, but:

- **Footgun** — the `sync.Once` was process-global, so a second provider instance (or a `Configure` call with a different `access_token` / `use_sandbox_env`) would silently reuse the first client, discarding the new config with no error.
- **`Configure` was untestable** — the global `sync.Once` is consumed after the first call, so no focused test could exercise it.
- Non-idiomatic — terraform-plugin-framework expects a provider *instance* to carry its configured state.

## Changes

- Move `client` / `batchClient` / `cacheClient` / `initErr` and a `sync.Once` onto `GeniProvider` as fields; `Configure` uses `p.once.Do(...)`.
- Add **`TestConfigure`** (now possible): drives `Configure` offline with a static token, and asserts client data is populated and that **separate provider instances get independent clients** — the property the refactor unlocks.

## Behaviour

Identical for production and the existing acceptance suite — both run a single shared `GeniProvider`. The change only matters once more than one instance exists, where each is now correctly independent.

Not addressed (out of scope, separate accepted item): the 3 batch goroutines still run on `context.Background()` with no shutdown — providers have no shutdown hook.

## Verification

- `go build ./...`, `make test` (incl. new `TestConfigure`), `golangci-lint run` — all pass.

CHANGELOG entry added under `0.21.5 (Unreleased)`.