### PR TITLE
test: de-flake union event-name acceptance test

### DIFF
--- a/test/acceptance/geni_union_test.go
+++ b/test/acceptance/geni_union_test.go
@@ -867,6 +867,12 @@ func TestAccUnion_createUnionWithTwoPartnersAndDetails(t *testing.T) {
 			{
 				Config: unionWithTwoPartnersAndDetails(),
 				ConfigStateChecks: []statecheck.StateCheck{
+					// Geni auto-generates the marriage/divorce event name from the
+					// partner names with non-deterministic ordering — accept either.
+					statecheck.ExpectKnownValue("geni_union.doe_family", tfjsonpath.New("marriage").AtMapKey("name"),
+						knownvalue.StringRegexp(regexp.MustCompile(`^Marriage of (John and Jane|Jane and John) Doe$`))),
+					statecheck.ExpectKnownValue("geni_union.doe_family", tfjsonpath.New("divorce").AtMapKey("name"),
+						knownvalue.StringRegexp(regexp.MustCompile(`^Divorce of (John and Jane|Jane and John) Doe$`))),
 					statecheck.ExpectKnownValue("geni_profile.husband", tfjsonpath.New("names").AtMapKey("en-US").AtMapKey("first_name"), knownvalue.StringExact("John")),
 					statecheck.ExpectKnownValue("geni_profile.wife", tfjsonpath.New("names").AtMapKey("en-US").AtMapKey("first_name"), knownvalue.StringExact("Jane")),
 					statecheck.ExpectKnownValue("geni_union.doe_family", tfjsonpath.New("partners"), knownvalue.SetSizeExact(2)),
@@ -911,7 +917,6 @@ func unionWithTwoPartnersAndDetails() string {
 		  ]
 
 		  marriage = {
-			name = "Marriage of John and Jane Doe"
 			date = {
 			  range = "between"
 			  year = 1980
@@ -935,7 +940,6 @@ func unionWithTwoPartnersAndDetails() string {
 		  }
 
 		  divorce = {
-			name = "Divorce of John and Jane Doe"
 			date = {
 			  range = "between"
 			  year = 1980


### PR DESCRIPTION
## Summary

`TestAccUnion_createUnionWithTwoPartnersAndDetails` has flaked intermittently across acceptance runs (#108, #113, #115). Root cause: the HCL config **pinned** `marriage.name` / `divorce.name` to `"... of John and Jane Doe"`, but Geni **auto-generates** those event names from the partner names with **non-deterministic ordering** — a refresh sometimes returns `"... of Jane and John Doe"`, yielding a phantom non-empty plan:

```
~ marriage = { ~ name = "Marriage of Jane and John Doe" -> "Marriage of John and Jane Doe" }
~ divorce  = { ~ name = "Divorce of Jane and John Doe"  -> "Divorce of John and Jane Doe"  }
```

## Fix

- Drop the pinned `name` from the `marriage` / `divorce` config blocks. `name` is `Computed` — Geni owns it — so leaving it unset removes the phantom diff entirely.
- Add `ConfigStateChecks` asserting each name via `knownvalue.StringRegexp`, accepting **either** ordering: `^Marriage of (John and Jane|Jane and John) Doe$` (and likewise for divorce). This still verifies the events are created and sensibly named — coverage the test previously lacked.

## Verification

`TF_ACC=1 go test -count=3 -run '^TestAccUnion_createUnionWithTwoPartnersAndDetails$'` — **3/3 pass** against the sandbox. `gofmt`, `go vet`, `golangci-lint` clean.

Test-only change; no CHANGELOG/docs entry.