### PR TITLE
fix(union): clean up orphans on a partial create/update failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.21.6 (Unreleased)
 
+BUG FIXES:
+
+* `geni_union`: a partial failure while building a union no longer leaks data on Geni. A union is assembled by creating temporary profiles and merging them into the real ones; when a `Merge` step failed, the orphan temporary profile was left live on Geni and untracked, and a failed `Create` also stranded the partially-built union — so the next apply created another. Now the orphan temporary profile is deleted on a failed merge, and a partially-built union is saved to state so Terraform tracks it and converges it on the next apply. (#118)
+
 ## 0.21.5
 
 IMPROVEMENTS:

--- a/internal/resource/union/create.go
+++ b/internal/resource/union/create.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	geniprofile "github.com/dmalch/go-geni/profile"
 	"github.com/dmalch/terraform-provider-genealogy/internal/tfset"
@@ -19,6 +18,16 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		return
 	}
 
+	// A union is built by creating temporary profiles and merging them into the
+	// real ones (Geni cannot link existing profiles directly). If a step fails
+	// after the union exists, persist it so Terraform tracks the partial union
+	// instead of stranding it and creating another on the next apply.
+	defer func() {
+		if resp.Diagnostics.HasError() {
+			persistPartialUnion(ctx, resp, plan)
+		}
+	}()
+
 	partnerIds, diags := tfset.Strings(ctx, plan.Partners)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -28,22 +37,16 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 	// If there are two partners, we can create a union by calling the profile/add-partner API
 	if len(plan.Partners.Elements()) == 2 {
 		// It is impossible to create a union from two existing profiles using the API,
-		// so we need to create a temporary partner profile and then merge it with the
-		// existing second partner profile.
-
-		tmpProfile, err := r.client.Profile().AddPartner(ctx, partnerIds[0])
+		// so we create a temporary partner profile and merge it with the existing
+		// second partner profile.
+		tmpProfile, err := r.addAndMerge(ctx, partnerIds[1], func(ctx context.Context) (*geniprofile.Profile, error) {
+			return r.client.Profile().AddPartner(ctx, partnerIds[0])
+		})
+		plan.ID = unionIDFrom(plan.ID, tmpProfile)
 		if err != nil {
 			resp.Diagnostics.AddAttributeError(path.Root(fieldPartners), "Error adding partner", err.Error())
 			return
 		}
-
-		// Merge the temporary profile with the second partner
-		if err := r.client.Profile().Merge(ctx, partnerIds[1], tmpProfile.ID); err != nil {
-			resp.Diagnostics.AddAttributeError(path.Root(fieldPartners), "Error merging profiles", err.Error())
-			return
-		}
-
-		plan.ID = types.StringValue(tmpProfile.Unions[0])
 	}
 
 	// Set the children. If the union already exists and has children, we can set
@@ -83,57 +86,40 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 
 			modifier := modifierFor(childId, fosterSet, adoptedSet)
 
+			// It is impossible to add an existing child profile to a union using
+			// the API, so create a temporary child profile and merge it with the
+			// existing child profile. addAndMerge deletes the temp profile if the
+			// merge fails.
 			var tmpProfile *geniprofile.Profile
-
-			// If the union already exists, we can add children to it
-			if !plan.ID.IsUnknown() && !plan.ID.IsNull() {
-				// It is impossible to add an existing child profile to a union using the API, so
-				// we need to create a temporary child profile and then merge it with the
-				// existing child profile.
-				var err error
-				tmpProfile, err = r.client.Union().AddChild(ctx, plan.ID.ValueString(), geniprofile.WithModifier(modifier))
-				if err != nil {
-					resp.Diagnostics.AddAttributeError(path.Root(fieldChildren), "Error adding child with ID="+childId, err.Error())
-					return
-				}
-			} else {
-				// When one parent is known, we can add a child to the parent
-				if len(partnerIds) > 0 {
-					// It is impossible to add an existing child profile to a parent using the API,
-					// so we need to create a temporary child profile and then merge it with the
-					// existing child profile.
-					var err error
-					tmpProfile, err = r.client.Profile().AddChild(ctx, partnerIds[0], geniprofile.WithModifier(modifier))
-					if err != nil {
-						resp.Diagnostics.AddAttributeError(path.Root(fieldChildren), "Error adding child with ID="+childId, err.Error())
-						return
-					}
-				} else if len(partnerIds) == 0 && len(allChildrenIds) > 1 {
-					// If there are no partners, we can add a child as a sibling to the next child
-					// in the union using the profile/add-sibling API.
-					// It is impossible to add an existing child profile to a sibling using the API,
-					// so we need to create a temporary child profile and then merge it with the
-					// existing child profile.
-					var err error
-					tmpProfile, err = r.client.Profile().AddSibling(ctx, allChildrenIds[i+1], geniprofile.WithModifier(modifier))
-					if err != nil {
-						resp.Diagnostics.AddAttributeError(path.Root(fieldChildren), "Error adding child with ID="+childId, err.Error())
-						return
-					}
-
-					// Skip the next iteration because we already added the child
-					skipNextIteration = true
-				}
+			var err error
+			switch {
+			case !plan.ID.IsUnknown() && !plan.ID.IsNull():
+				// The union already exists — add the child to it.
+				tmpProfile, err = r.addAndMerge(ctx, childId, func(ctx context.Context) (*geniprofile.Profile, error) {
+					return r.client.Union().AddChild(ctx, plan.ID.ValueString(), geniprofile.WithModifier(modifier))
+				})
+			case len(partnerIds) > 0:
+				// When one parent is known, add the child to the parent.
+				tmpProfile, err = r.addAndMerge(ctx, childId, func(ctx context.Context) (*geniprofile.Profile, error) {
+					return r.client.Profile().AddChild(ctx, partnerIds[0], geniprofile.WithModifier(modifier))
+				})
+			case len(allChildrenIds) > 1:
+				// With no partners, add the child as a sibling of the next child.
+				tmpProfile, err = r.addAndMerge(ctx, childId, func(ctx context.Context) (*geniprofile.Profile, error) {
+					return r.client.Profile().AddSibling(ctx, allChildrenIds[i+1], geniprofile.WithModifier(modifier))
+				})
+				// Skip the next iteration because we already added that child.
+				skipNextIteration = true
+			default:
+				// A single child with no parents cannot be attached; ValidateConfig
+				// rejects this configuration before Create runs.
+				continue
 			}
 
-			// Merge the temporary profile with the child profile
-			if err := r.client.Profile().Merge(ctx, childId, tmpProfile.ID); err != nil {
-				resp.Diagnostics.AddAttributeError(path.Root(fieldChildren), "Error merging profiles", err.Error())
+			plan.ID = unionIDFrom(plan.ID, tmpProfile)
+			if err != nil {
+				resp.Diagnostics.AddAttributeError(path.Root(fieldChildren), "Error adding child with ID="+childId, err.Error())
 				return
-			}
-
-			if plan.ID.IsUnknown() || plan.ID.IsNull() {
-				plan.ID = types.StringValue(tmpProfile.Unions[0])
 			}
 		}
 	}

--- a/internal/resource/union/temp_profile.go
+++ b/internal/resource/union/temp_profile.go
@@ -1,0 +1,70 @@
+package union
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
+	geniprofile "github.com/dmalch/go-geni/profile"
+	"github.com/dmalch/terraform-provider-genealogy/internal/resource/event"
+)
+
+// addAndMerge creates a temporary Geni profile via create and merges it into the
+// existing profile realID. Geni has no API to link two existing profiles into a
+// union, so every union edge is built create-then-merge.
+//
+// If the merge fails the temporary profile is an orphan — live on Geni but
+// untracked by Terraform — so addAndMerge best-effort deletes it. The temp
+// profile is returned even on merge failure (alongside the error) so the caller
+// can still recover the union id from tmp.Unions for partial-state persistence.
+func (r *Resource) addAndMerge(
+	ctx context.Context,
+	realID string,
+	create func(context.Context) (*geniprofile.Profile, error),
+) (*geniprofile.Profile, error) {
+	tmp, err := create(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := r.client.Profile().Merge(ctx, realID, tmp.ID); err != nil {
+		if delErr := r.client.Profile().Delete(ctx, tmp.ID); delErr != nil {
+			tflog.Error(ctx, "failed to delete orphan temporary profile after a failed merge",
+				map[string]interface{}{"profile_id": tmp.ID, "error": delErr})
+		}
+		return tmp, err
+	}
+
+	return tmp, nil
+}
+
+// unionIDFrom returns the union id once it is known: the current value if it is
+// already set, otherwise the union the temporary profile was created in.
+func unionIDFrom(current types.String, tmp *geniprofile.Profile) types.String {
+	if !current.IsUnknown() && !current.IsNull() {
+		return current
+	}
+	if tmp != nil && len(tmp.Unions) > 0 {
+		return types.StringValue(tmp.Unions[0])
+	}
+	return current
+}
+
+// persistPartialUnion writes a union that was created but not fully configured
+// into state, so a failed Create does not strand it untracked — which would
+// otherwise make the next apply create yet another union. Marriage and Divorce
+// are nulled because their computed fields are still unresolved on the failure
+// path; the next Read repopulates them from the API.
+func persistPartialUnion(ctx context.Context, resp *resource.CreateResponse, plan ResourceModel) {
+	if plan.ID.IsUnknown() || plan.ID.IsNull() {
+		return // no union was created — nothing to track
+	}
+
+	plan.Marriage = types.ObjectNull(event.EventModelAttributeTypes())
+	plan.Divorce = types.ObjectNull(event.EventModelAttributeTypes())
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+	resp.Diagnostics.Append(resp.Identity.Set(ctx, ResourceIdentityModel{ID: plan.ID})...)
+}

--- a/internal/resource/union/temp_profile_test.go
+++ b/internal/resource/union/temp_profile_test.go
@@ -1,0 +1,42 @@
+package union
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	. "github.com/onsi/gomega"
+
+	geniprofile "github.com/dmalch/go-geni/profile"
+)
+
+func TestUnionIDFrom(t *testing.T) {
+	t.Run("Keeps an already-known union id", func(t *testing.T) {
+		RegisterTestingT(t)
+		got := unionIDFrom(types.StringValue("union-1"), &geniprofile.Profile{Unions: []string{"union-9"}})
+		Expect(got.ValueString()).To(Equal("union-1"))
+	})
+
+	t.Run("Adopts the temp profile's union when the id is null", func(t *testing.T) {
+		RegisterTestingT(t)
+		got := unionIDFrom(types.StringNull(), &geniprofile.Profile{Unions: []string{"union-9"}})
+		Expect(got.ValueString()).To(Equal("union-9"))
+	})
+
+	t.Run("Adopts the temp profile's union when the id is unknown", func(t *testing.T) {
+		RegisterTestingT(t)
+		got := unionIDFrom(types.StringUnknown(), &geniprofile.Profile{Unions: []string{"union-9"}})
+		Expect(got.ValueString()).To(Equal("union-9"))
+	})
+
+	t.Run("Stays null when there is no temp profile", func(t *testing.T) {
+		RegisterTestingT(t)
+		got := unionIDFrom(types.StringNull(), nil)
+		Expect(got.IsNull()).To(BeTrue())
+	})
+
+	t.Run("Stays null when the temp profile has no unions", func(t *testing.T) {
+		RegisterTestingT(t)
+		got := unionIDFrom(types.StringNull(), &geniprofile.Profile{})
+		Expect(got.IsNull()).To(BeTrue())
+	})
+}

--- a/internal/resource/union/update.go
+++ b/internal/resource/union/update.go
@@ -58,19 +58,13 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		for _, partnerId := range planPartnerIds {
 			// If the partner is not in the state, we need to add it
 			if _, ok := knownStatePartnerIds[partnerId]; !ok {
-				// It is impossible to add an existing profile to a union using the API, so we
-				// need to create a temporary profile and then merge it with the existing
-				// profile.
-
-				tmpProfile, err := r.client.Union().AddPartner(ctx, plan.ID.ValueString())
-				if err != nil {
+				// It is impossible to add an existing profile to a union using the
+				// API, so create a temporary profile and merge it with the existing
+				// one. addAndMerge deletes the temp profile if the merge fails.
+				if _, err := r.addAndMerge(ctx, partnerId, func(ctx context.Context) (*geniprofile.Profile, error) {
+					return r.client.Union().AddPartner(ctx, plan.ID.ValueString())
+				}); err != nil {
 					resp.Diagnostics.AddAttributeError(path.Root(fieldPartners), "Error adding partner", err.Error())
-					return
-				}
-
-				// Merge the temporary profile with the second partner
-				if err := r.client.Profile().Merge(ctx, partnerId, tmpProfile.ID); err != nil {
-					resp.Diagnostics.AddAttributeError(path.Root(fieldPartners), "Error merging profiles", err.Error())
 					return
 				}
 			}
@@ -143,20 +137,14 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		for _, childId := range planAll {
 			// If the child is not in the state, we need to add it
 			if _, ok := knownStateAll[childId]; !ok {
-				// It is impossible to add an existing profile to a union using the API, so we
-				// need to create a temporary profile and then merge it with the existing
-				// profile.
-
+				// It is impossible to add an existing profile to a union using the
+				// API, so create a temporary profile and merge it with the existing
+				// one. addAndMerge deletes the temp profile if the merge fails.
 				modifier := modifierFor(childId, fosterSet, adoptedSet)
-				tmpProfile, err := r.client.Union().AddChild(ctx, plan.ID.ValueString(), geniprofile.WithModifier(modifier))
-				if err != nil {
+				if _, err := r.addAndMerge(ctx, childId, func(ctx context.Context) (*geniprofile.Profile, error) {
+					return r.client.Union().AddChild(ctx, plan.ID.ValueString(), geniprofile.WithModifier(modifier))
+				}); err != nil {
 					resp.Diagnostics.AddAttributeError(path.Root(fieldChildren), "Error adding child with ID="+childId, err.Error())
-					return
-				}
-
-				// Merge the temporary profile with the child profile
-				if err := r.client.Profile().Merge(ctx, childId, tmpProfile.ID); err != nil {
-					resp.Diagnostics.AddAttributeError(path.Root(fieldChildren), "Error merging profiles", err.Error())
 					return
 				}
 			}


### PR DESCRIPTION
## Summary

Fixes the Medium finding from the codebase review: `geni_union` create/update leaks data on a partial failure.

A union is assembled by creating **temporary Geni profiles** and merging them into the real ones (Geni's API can't link existing profiles directly). Two leaks on a partial failure:

- A failed `Merge` left the temporary profile **live on Geni and untracked** by Terraform — a stray genealogy record.
- A failed `Create` also stranded the **partially-built union itself**: state was never written, so the next apply created *another* union — piling up on repeated failures.

## Constraint

A true rollback is impossible — go-geni's API has **no union-delete and no remove-partner/remove-child**. So the fix cleans up what *is* deletable and makes the rest trackable. A **Phase 0 spike confirmed** `Profile().Delete` succeeds on a profile that is currently a union member.

## Changes (`internal/resource/union/temp_profile.go`)

- **`addAndMerge`** — wraps the create-temp-then-merge pattern (4 inlined call sites across `create.go`/`update.go`). On merge failure it best-effort deletes the orphan temporary profile.
- **`persistPartialUnion`** — a deferred call in `Create` that, when `Create` fails after the union exists, saves the union to state so Terraform tracks it and converges it on the next apply. Marriage/Divorce are nulled (their computed fields are unresolved on the failure path; the next `Read` repopulates them).
- **`unionIDFrom`** — captures the union id as soon as it's known, including on the merge-failure path.

## Tests

`TestUnionIDFrom` covers the id-capture helper. Existing union unit + acceptance tests cover the happy path (create-temp-merge is unchanged on success).

**Coverage gap (honest):** the failure paths (`addAndMerge`'s delete-on-failure, `persistPartialUnion`) can't be exercised without forcing a Geni `Merge` to fail — that would need the client behind an interface for fault injection. Flagged as possible follow-up.

## Verification

- `go build ./...`, `make test`, `golangci-lint run` — all pass.

CHANGELOG entry added under `0.21.6 (Unreleased)`.