### PR TITLE
fix(union): clear marriage and divorce when block removed from config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## 0.22.1 (Unreleased)
 
+BUG FIXES:
+
+* `resource/union`: clear `marriage` and `divorce` when the block is removed
+  from configuration. The provider now calls go-geni's new `WipeEvents`,
+  which POSTs `{"marriage": {"date": {}, "location": {}}}` — the only
+  payload Geni's union endpoint honors as a clear. (Geni rejects
+  `"marriage": null` with HTTP 500 and silently deep-merges `"marriage": {}`.)
+
 ## 0.22.0
 
 FEATURES:

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26
 
 require (
 	github.com/allegro/bigcache/v3 v3.1.0
-	github.com/dmalch/go-geni v1.2.0
+	github.com/dmalch/go-geni v1.8.0
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/hashicorp/terraform-plugin-go v0.31.0

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dmalch/go-geni v1.2.0 h1:A8ZRf1NQ0PUzB5sS7tLdfg2NeQjJV3soC3olNcsd8FQ=
-github.com/dmalch/go-geni v1.2.0/go.mod h1:NcJTWX4cRfWbUj8+Ztkg3/q6Xx8p7pDsmXUaMOoHp3M=
+github.com/dmalch/go-geni v1.8.0 h1:n8u8xUz2EvXsNAzjlwyye/bFDyee5oxUcrH03M4KGmE=
+github.com/dmalch/go-geni v1.8.0/go.mod h1:NcJTWX4cRfWbUj8+Ztkg3/q6Xx8p7pDsmXUaMOoHp3M=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=

--- a/internal/resource/union/temp_profile.go
+++ b/internal/resource/union/temp_profile.go
@@ -29,7 +29,7 @@ func (r *Resource) addAndMerge(
 		return nil, err
 	}
 
-	if err := r.client.Profile().Merge(ctx, realID, tmp.ID); err != nil {
+	if _, err := r.client.Profile().Merge(ctx, realID, tmp.ID); err != nil {
 		if delErr := r.client.Profile().Delete(ctx, tmp.ID); delErr != nil {
 			tflog.Error(ctx, "failed to delete orphan temporary profile after a failed merge",
 				map[string]interface{}{"profile_id": tmp.ID, "error": delErr})

--- a/internal/resource/union/update.go
+++ b/internal/resource/union/update.go
@@ -159,6 +159,24 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 			return
 		}
 
+		// Pre-wipe entire events that the plan removes (block dropped entirely).
+		// Geni's union endpoint rejects null ("value must be a hash!") so the
+		// only sentinel that works is {} (empty hash). We must do this before
+		// the regular Update so omitempty doesn't silently skip the cleared field.
+		var wholeEventWipeKeys []string
+		if !state.Marriage.IsNull() && plan.Marriage.IsNull() {
+			wholeEventWipeKeys = append(wholeEventWipeKeys, "marriage")
+		}
+		if !state.Divorce.IsNull() && plan.Divorce.IsNull() {
+			wholeEventWipeKeys = append(wholeEventWipeKeys, "divorce")
+		}
+		if len(wholeEventWipeKeys) > 0 {
+			if err := r.client.Profile().WipeEvents(ctx, plan.ID.ValueString(), wholeEventWipeKeys); err != nil {
+				resp.Diagnostics.AddError("Error clearing event fields", err.Error())
+				return
+			}
+		}
+
 		// Pre-wipe event dates that the plan partially clears — Geni's PATCH
 		// deep-merges nested objects so per-key nulls inside `date` are no-ops
 		// (#94). Cost is one extra PATCH per Update that hits this case.

--- a/test/acceptance/geni_union_test.go
+++ b/test/acceptance/geni_union_test.go
@@ -1319,3 +1319,84 @@ func TestAccUnion_clearMarriageDateSubFieldPersists(t *testing.T) {
 		},
 	})
 }
+
+// TestAccUnion_clearMarriageEntirelyPersists verifies that removing the entire
+// marriage block from HCL causes the event to be cleared on Geni server-side
+// and stays cleared (no drift) on the next plan. This exercises the fix in
+// go-geni where Request.Marriage was tagged omitempty, causing nil to be
+// dropped from the wire body; Geni saw no field and silently kept the event.
+func TestAccUnion_clearMarriageEntirelyPersists(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					resource "geni_profile" "husband" {
+					  names = { "en-US" = { first_name = "John", last_name = "Doe" } }
+					  alive  = false
+					  public = true
+					}
+					resource "geni_profile" "wife" {
+					  names = { "en-US" = { first_name = "Jane", last_name = "Doe" } }
+					  alive  = false
+					  public = true
+					}
+					resource "geni_union" "doe_family" {
+					  partners = [geni_profile.husband.id, geni_profile.wife.id]
+					  marriage = {
+						date = {
+						  year  = 1909
+						  month = 8
+						  range = "before"
+						}
+					  }
+					}
+				`,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("geni_union.doe_family", tfjsonpath.New("marriage").AtMapKey("date").AtMapKey("year"), knownvalue.Int32Exact(1909)),
+				},
+			},
+			{
+				Config: `
+					resource "geni_profile" "husband" {
+					  names = { "en-US" = { first_name = "John", last_name = "Doe" } }
+					  alive  = false
+					  public = true
+					}
+					resource "geni_profile" "wife" {
+					  names = { "en-US" = { first_name = "Jane", last_name = "Doe" } }
+					  alive  = false
+					  public = true
+					}
+					resource "geni_union" "doe_family" {
+					  partners = [geni_profile.husband.id, geni_profile.wife.id]
+					  # marriage block intentionally absent
+					}
+				`,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("geni_union.doe_family", tfjsonpath.New("marriage"), knownvalue.Null()),
+				},
+			},
+			{
+				// Refresh + plan only. Asserts no drift on Geni's side after the clear.
+				Config: `
+					resource "geni_profile" "husband" {
+					  names = { "en-US" = { first_name = "John", last_name = "Doe" } }
+					  alive  = false
+					  public = true
+					}
+					resource "geni_profile" "wife" {
+					  names = { "en-US" = { first_name = "Jane", last_name = "Doe" } }
+					  alive  = false
+					  public = true
+					}
+					resource "geni_union" "doe_family" {
+					  partners = [geni_profile.husband.id, geni_profile.wife.id]
+					}
+				`,
+				PlanOnly: true,
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Summary

- Removing a `marriage` or `divorce` block from a `geni_union` resource no longer leaves the event data on Geni.
- Bumps `github.com/dmalch/go-geni` to v1.8.0, which adds `Client.WipeEvents`.

## Root cause

The prior update path omitted removed-event keys entirely (due to `omitempty`). Geni treats missing keys as no-ops — it deep-merges, never deletes. So a removed `marriage {}` block had no effect on the live record.

## Fix

Before the regular union update, the provider now calls `go-geni`'s new `WipeEvents(ctx, id, keys)` for each event key that was present in state but is absent in the plan. `WipeEvents` POSTs `{"<event>": {"date": {}, "location": {}}}` — the only payload Geni honors as a clear:

- `"marriage": null` → HTTP 500 "value must be a hash!"
- `"marriage": {}` → silent no-op (deep-merge, existing date/location survive)
- `"marriage": {"date": {}, "location": {}}` → clears both sub-fields ✓

Geni auto-regenerates a name-only stub afterward; the provider already treats `date == nil && location == nil` as a cleared event, so no further changes are needed.

See go-geni PR [dmalch/go-geni#55](https://github.com/dmalch/go-geni/pull/55) for the library implementation.

## Changes

- `internal/resource/union/update.go` — call `WipeEvents` for removed event keys before the regular update call.
- `internal/resource/union/temp_profile.go` — update call site for the `Merge` signature change (`(*Result, error)`) from go-geni v1.5.0.
- `go.mod` / `go.sum` — bump `go-geni` to v1.8.0, remove local `replace` directive.
- `test/acceptance/geni_union_test.go` — add `TestAccUnion_clearMarriageEntirelyPersists`.
- `CHANGELOG.md` — BUG FIXES entry under `0.22.1 (Unreleased)`.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — clean (acceptance tests gated by `TF_ACC=1`)
- [x] `golangci-lint run ./...` — 0 issues
- [x] `make docs` — no diff (schema unchanged)
- [ ] `TF_ACC=1 go test ./test/acceptance/ -run TestAccUnion_clearMarriageEntirelyPersists -timeout 10m` — verified end-to-end in sandbox prior to this PR