### PR TITLE
fix: retry HTTP/2 RST_STREAM errors at high parallelism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## 0.22.2 (Unreleased)
 
+BUG FIXES:
+
+* Retry HTTP/2 `RST_STREAM` errors (`CANCEL` / `REFUSED_STREAM`). Geni's
+  HTTP/2 frontend cancels streams instead of returning 429 when a client
+  exceeds its rolling rate-limit window, so a high-parallelism
+  `terraform apply` (e.g. `-parallelism=200` against ~1k pending
+  `geni_profile` creates) could cascade-fail once the window was
+  exhausted. Those failures are now classified as transient and retried;
+  the dynamic limiter re-tunes from `X-API-Rate-*` response headers on
+  the next successful response. Ships in go-geni v1.9.1. (#122)
+
 ## 0.22.1
 
 BUG FIXES:

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26
 
 require (
 	github.com/allegro/bigcache/v3 v3.1.0
-	github.com/dmalch/go-geni v1.8.0
+	github.com/dmalch/go-geni v1.9.1
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/hashicorp/terraform-plugin-go v0.31.0

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dmalch/go-geni v1.8.0 h1:n8u8xUz2EvXsNAzjlwyye/bFDyee5oxUcrH03M4KGmE=
-github.com/dmalch/go-geni v1.8.0/go.mod h1:NcJTWX4cRfWbUj8+Ztkg3/q6Xx8p7pDsmXUaMOoHp3M=
+github.com/dmalch/go-geni v1.9.1 h1:EAm8wW0lNXmjJbHDjo7Ks+zKQKDQcOjYj73fbsXgcQE=
+github.com/dmalch/go-geni v1.9.1/go.mod h1:a1MQ1BTAJKHF9Hf0zkfsObpMm37fdkKw0NcKVUMUqfY=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=


### PR DESCRIPTION
## Summary

- Bump `github.com/dmalch/go-geni` to **v1.9.1** which classifies `*http2.StreamError` (CANCEL / REFUSED_STREAM and friends) as transient in `translateTransportError`, so the retry-go RetryIf hook picks them up.
- Add a CHANGELOG entry under `0.22.2 (Unreleased)`.

## Why

Geni's HTTP/2 frontend cancels streams instead of returning `429` when a client exceeds its rolling rate-limit window (`X-API-Rate-Limit` / `X-API-Rate-Window`). The previous classifier only matched `"broken pipe"` / `"connection reset by peer"` substrings on `*net.OpError`, so `http2.StreamError` slipped through as non-transient and the SDK gave up after one attempt.

This caused #122: a `terraform apply -parallelism=200` against ~1k pending `geni_profile` creates cascade-failed once Geni's per-token quota was saturated, even though the dynamic limiter would re-tune correctly from the next successful response's headers.

Fixes #122. Companion change: dmalch/go-geni#57.

## Test plan

- [x] `go mod tidy && go mod vendor` clean
- [x] `make test` (unit) clean
- [x] `make build`
- [x] `TF_ACC=1 go test -v ./test/acceptance/ -timeout 60m` against sandbox: profile / union / project / data-source suites all pass; pre-existing `geni_document` / `geni_photo` destroy failures tracked separately in #123 and unrelated to this change.