### PR TITLE
fix(document, photo): translate empty bulk envelope to not-found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## 0.22.3 (Unreleased)
 
+BUG FIXES:
+
+* `resource/geni_document`, `resource/geni_photo`: a `terraform destroy`
+  now correctly observes the resource as gone on the next `Read`.
+  Previously Geni's empty bulk-envelope reply (`{"results": []}`) to a
+  singular `/api/<id>` GET against a deleted document or photo was
+  silently unmarshaled into a zero-valued struct, so the provider
+  treated the deleted resource as still present and reported drift
+  (and acceptance tests' `CheckDestroy` fixture reported "still
+  exists"). Fixed in go-geni v1.9.2 by translating that response shape
+  into `ErrResourceNotFound`. (#123)
+
 ## 0.22.2
 
 BUG FIXES:

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26
 
 require (
 	github.com/allegro/bigcache/v3 v3.1.0
-	github.com/dmalch/go-geni v1.9.1
+	github.com/dmalch/go-geni v1.9.2
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/hashicorp/terraform-plugin-go v0.31.0

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dmalch/go-geni v1.9.1 h1:EAm8wW0lNXmjJbHDjo7Ks+zKQKDQcOjYj73fbsXgcQE=
-github.com/dmalch/go-geni v1.9.1/go.mod h1:a1MQ1BTAJKHF9Hf0zkfsObpMm37fdkKw0NcKVUMUqfY=
+github.com/dmalch/go-geni v1.9.2 h1:+D048GGpLW4VlB7fk9K5MgBTD/XPSk0wo9w0SRfM+Ag=
+github.com/dmalch/go-geni v1.9.2/go.mod h1:a1MQ1BTAJKHF9Hf0zkfsObpMm37fdkKw0NcKVUMUqfY=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=


### PR DESCRIPTION
## Summary

- Bump `github.com/dmalch/go-geni` to **v1.9.2**.
- CHANGELOG entry under `0.22.3 (Unreleased)`.

## Why

`terraform destroy` of a `geni_document` or `geni_photo` succeeded against Geni's API but the subsequent `Read` saw a zero-valued struct instead of "not found," so the provider believed the deleted resource was still in place. Symptom in acceptance: `Error running post-test destroy, there may be dangling resources: document <id> still exists` (18 such failures in `TestAccDocument_*` and `TestAccPhoto_*` — see #123).

Root cause: Geni's singular `/api/<id>` endpoint returns the empty bulk-envelope shape (`{"results": []}`) — **not** a 404 — when the target is deleted on the document and photo endpoints. The SDK's transport coalescer was passing that envelope through to `json.Unmarshal` as if it were a singular `Document` / `Photo`, producing a zero-valued struct.

[go-geni v1.9.2](https://github.com/dmalch/go-geni/pull/58) translates the empty-envelope shape into `ErrResourceNotFound` in `BulkCoalescer.ParseBulkResponse`. The provider's existing `ErrResourceNotFound` branch in both `internal/resource/document/read.go:38` and `internal/resource/photo/read.go:38` already calls `resp.State.RemoveResource(ctx)`, so no provider code change is needed — just the dependency bump.

Profile's separate `deleted: true` flag is untouched: Geni returns `{"id": ..., "deleted": true, "results": null}` for deleted profiles, and `results: null` decodes to a nil `Results` slice, which the new coalescer branch treats as singular shape and passes through (preserving the existing `Profile.Deleted` inspection in `internal/resource/profile/read.go:48-67`).

Fixes #123. Companion change: dmalch/go-geni#58.

## Test plan

- [x] `go mod tidy && go mod vendor` clean.
- [x] `make test` (unit) clean.
- [x] `make build`.
- [x] `TF_ACC=1 go test -v ./test/acceptance/ -run 'TestAccDocument|TestAccPhoto' -timeout 30m` — **20/20 PASS** against the sandbox (every `TestAccDocument_*` and `TestAccPhoto_*` spec including the previously-failing `_listResources` / `_createTextDocument` / `_createPhoto` / etc.).