### PR TITLE
fix(profile): preserve planned unions set across Create/Update (#128)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## 0.22.4 (Unreleased)
 
+BUG FIXES:
+
+* `resource/geni_profile`: stop overwriting the `unions` computed set in
+  state from the Geni API response captured during Create/Update. When
+  sibling `geni_union` resources are being created or destroyed in the
+  same plan graph, that response reflects an intermediate Geni state and
+  caused Terraform to surface `Provider produced inconsistent result
+  after apply` on `.unions`. The Read path now solely populates `unions`
+  from the API on the next refresh. (#128)
+
 ## 0.22.3
 
 BUG FIXES:

--- a/internal/resource/profile/convert.go
+++ b/internal/resource/profile/convert.go
@@ -277,9 +277,12 @@ func UpdateComputedFields(ctx context.Context, profile *geniprofile.Profile, pro
 		profileModel.Guid = types.StringNull()
 	}
 
-	unions, diags := types.SetValueFrom(ctx, types.StringType, profile.Unions)
-	d.Append(diags...)
-	profileModel.Unions = unions
+	// Unions is intentionally not updated here: in the same plan graph
+	// that updates this profile, sibling geni_union creates/destroys may
+	// not yet have applied when the API response is captured, so
+	// profile.Unions is an intermediate value and would trigger
+	// Terraform's post-apply consistency check on .unions (issue #128).
+	// The Read path's ValueFrom populates unions on the next refresh.
 
 	// Projects is intentionally not updated here: Create/Update pass the
 	// pre-link API response (the AddProfileToProject calls fire afterwards),

--- a/internal/resource/profile/convert_test.go
+++ b/internal/resource/profile/convert_test.go
@@ -241,13 +241,15 @@ func TestRequestFrom(t *testing.T) {
 }
 
 func TestUpdateComputedFields(t *testing.T) {
-	t.Run("Updates ID, unions, events, about, deleted, merged_into, and created_at", func(t *testing.T) {
+	t.Run("Updates ID, events, about, deleted, merged_into, and created_at", func(t *testing.T) {
 		RegisterTestingT(t)
 		givenProfile := &geniprofile.Profile{
-			ID:     "profile-123",
-			Unions: []string{"union-1", "union-2"},
-			// Projects intentionally omitted: Create/Update pass the pre-link
-			// API response, so it is stale and must not overwrite plan.Projects.
+			ID: "profile-123",
+			// Unions and Projects intentionally set to stale values: the
+			// Create/Update API response is captured before sibling
+			// geni_union / project link operations in the same plan graph
+			// land, so it must not overwrite the planned values.
+			Unions:   []string{"union-stale-1", "union-stale-2"},
 			Projects: []string{"project-stale"},
 			Birth: &geniprofile.EventElement{
 				Name: "Birth",
@@ -261,6 +263,9 @@ func TestUpdateComputedFields(t *testing.T) {
 			CreatedAt:  "1719709400",
 		}
 
+		planUnions, planUnionsDiags := types.SetValueFrom(t.Context(), types.StringType, []string{"union-from-plan"})
+		Expect(planUnionsDiags.HasError()).To(BeFalse())
+
 		planProjects, planProjectsDiags := types.SetValueFrom(t.Context(), types.StringType, []string{"project-from-plan"})
 		Expect(planProjectsDiags.HasError()).To(BeFalse())
 
@@ -271,6 +276,7 @@ func TestUpdateComputedFields(t *testing.T) {
 			Burial:           types.ObjectNull(event.EventModelAttributeTypes()),
 			CurrentResidence: types.ObjectNull(event.LocationModelAttributeTypes()),
 			About:            types.MapNull(types.StringType),
+			Unions:           planUnions,
 			Projects:         planProjects,
 		}
 
@@ -278,7 +284,13 @@ func TestUpdateComputedFields(t *testing.T) {
 
 		Expect(diags.HasError()).To(BeFalse())
 		Expect(model.ID.ValueString()).To(Equal("profile-123"))
-		Expect(model.Unions.Elements()).To(HaveLen(2))
+		// Unions in the plan must survive: the API response passed to
+		// UpdateComputedFields is captured before sibling geni_union
+		// creates/destroys land, so its Unions field is an intermediate
+		// value and must not overwrite the plan (issue #128).
+		var actualUnions []string
+		Expect(model.Unions.ElementsAs(t.Context(), &actualUnions, false).HasError()).To(BeFalse())
+		Expect(actualUnions).To(ConsistOf("union-from-plan"))
 		// Projects in the plan must survive: the API response passed to
 		// UpdateComputedFields is captured before AddProfileToProject runs,
 		// so its Projects field is stale and must not overwrite the plan.


### PR DESCRIPTION
## Summary

- Stop overwriting `geni_profile.unions` in `UpdateComputedFields` from the Geni API response captured during Create/Update — that response reflects an intermediate state when sibling `geni_union` resources are being created/destroyed in the same plan graph and triggered Terraform's `Provider produced inconsistent result after apply` check on `.unions`.
- The Read path's `ValueFrom` remains the sole writer of `unions` from the API, so state converges on the next refresh. This mirrors the existing `projects` workaround established for #89.
- Fixes #128.

## Test plan

- [x] `go test -v ./internal/resource/profile/ -run TestUpdateComputedFields` — unit test extended to assert the planned `unions` survives a stale API response (red before the fix, green after).
- [x] `go test ./...` — full unit suite green.
- [x] `make docs` — no diff (no schema change).
- [ ] Re-run the user's previously failing consolidation `terraform apply` and confirm no `inconsistent result` errors on the affected profiles.