### PR TITLE
chore(deps): bump go-geni to v1.16.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26
 
 require (
 	github.com/allegro/bigcache/v3 v3.1.0
-	github.com/dmalch/go-geni v1.13.0
+	github.com/dmalch/go-geni v1.16.0
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/hashicorp/terraform-plugin-go v0.31.0

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dmalch/go-geni v1.13.0 h1:9nXO4gkm/aV7N4HwFK9eU7EU1alzdjAOG4V8sEhGYQ8=
-github.com/dmalch/go-geni v1.13.0/go.mod h1:0ek9/rXCdoYgmUZDkfJxBIRMVGueYuEpv0E0FROmWCw=
+github.com/dmalch/go-geni v1.16.0 h1:kEjML3OxnFmNsXspinBS7WNrcSD1I7eSMa1FoLUB3jQ=
+github.com/dmalch/go-geni v1.16.0/go.mod h1:0ek9/rXCdoYgmUZDkfJxBIRMVGueYuEpv0E0FROmWCw=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=


### PR DESCRIPTION
## Summary

- Bump `github.com/dmalch/go-geni` v1.13.0 → v1.16.0.
- v1.14.0–v1.16.0 add features to the `cmd/geni` CLI tool only (`matches list`, `matches for-profile`, `-browser` flag + persistent config) — no library-side changes affect the provider.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — full unit suite green