### PR TITLE
refactor(profile): make unions read-only Computed attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 ## 0.22.6 (Unreleased)
 
+BREAKING CHANGES:
+
+* `resource/geni_profile`: the `unions` attribute is now read-only.
+  It was previously declared `Optional + Computed`, but the provider
+  has never sent `unions` to the Geni API — any HCL block setting
+  `unions = [...]` was a no-op and must be removed from configuration.
+
+BUG FIXES:
+
+* `resource/geni_profile`: removing `UseStateForUnknown` from `unions`
+  eliminates the root cause of the post-apply consistency error
+  addressed by the #128 workaround. Plans now show
+  `unions = (known after apply)` whenever the profile is updated,
+  matching the fact that sibling `geni_union` create/destroy in the
+  same apply can change the value.
+
 ## 0.22.5
 
 IMPROVEMENTS:

--- a/docs/resources/profile.md
+++ b/docs/resources/profile.md
@@ -39,11 +39,11 @@ description: |-
 - `projects` (Set of String) List of project IDs.
 - `suffix` (String) Profile's name suffix (e.g. "Jr.", "III").
 - `title` (String) Profile's name title (e.g. "Dr.", "Sir").
-- `unions` (Set of String) List of union IDs.
 
 ### Read-Only
 
 - `guid` (String) The globally unique identifier (GUID) for the profile, as assigned by Geni.
+- `unions` (Set of String) List of union IDs the profile belongs to. Computed from Geni on refresh.
 
 <a id="nestedatt--baptism"></a>
 ### Nested Schema for `baptism`

--- a/internal/resource/profile/convert.go
+++ b/internal/resource/profile/convert.go
@@ -277,12 +277,12 @@ func UpdateComputedFields(ctx context.Context, profile *geniprofile.Profile, pro
 		profileModel.Guid = types.StringNull()
 	}
 
-	// Unions is intentionally not updated here: in the same plan graph
-	// that updates this profile, sibling geni_union creates/destroys may
-	// not yet have applied when the API response is captured, so
-	// profile.Unions is an intermediate value and would trigger
-	// Terraform's post-apply consistency check on .unions (issue #128).
-	// The Read path's ValueFrom populates unions on the next refresh.
+	// Unions is Computed-only on the resource schema, so the planned set
+	// is Unknown at Create/Update time — overwriting it from the live API
+	// response cannot trigger Terraform's post-apply consistency check.
+	unions, diags := types.SetValueFrom(ctx, types.StringType, profile.Unions)
+	d.Append(diags...)
+	profileModel.Unions = unions
 
 	// Projects is intentionally not updated here: Create/Update pass the
 	// pre-link API response (the AddProfileToProject calls fire afterwards),

--- a/internal/resource/profile/convert_test.go
+++ b/internal/resource/profile/convert_test.go
@@ -241,15 +241,17 @@ func TestRequestFrom(t *testing.T) {
 }
 
 func TestUpdateComputedFields(t *testing.T) {
-	t.Run("Updates ID, events, about, deleted, merged_into, and created_at", func(t *testing.T) {
+	t.Run("Updates ID, unions, events, about, deleted, merged_into, and created_at", func(t *testing.T) {
 		RegisterTestingT(t)
 		givenProfile := &geniprofile.Profile{
 			ID: "profile-123",
-			// Unions and Projects intentionally set to stale values: the
-			// Create/Update API response is captured before sibling
-			// geni_union / project link operations in the same plan graph
-			// land, so it must not overwrite the planned values.
-			Unions:   []string{"union-stale-1", "union-stale-2"},
+			// Unions is Computed-only on the resource schema, so any planned
+			// value is Unknown at apply time and the live API response is the
+			// authoritative source here.
+			Unions: []string{"union-1", "union-2"},
+			// Projects is intentionally set to a stale value: the Create/Update
+			// API response is captured before the AddProfileToProject calls run,
+			// so it must not overwrite the planned project list.
 			Projects: []string{"project-stale"},
 			Birth: &geniprofile.EventElement{
 				Name: "Birth",
@@ -263,9 +265,6 @@ func TestUpdateComputedFields(t *testing.T) {
 			CreatedAt:  "1719709400",
 		}
 
-		planUnions, planUnionsDiags := types.SetValueFrom(t.Context(), types.StringType, []string{"union-from-plan"})
-		Expect(planUnionsDiags.HasError()).To(BeFalse())
-
 		planProjects, planProjectsDiags := types.SetValueFrom(t.Context(), types.StringType, []string{"project-from-plan"})
 		Expect(planProjectsDiags.HasError()).To(BeFalse())
 
@@ -276,7 +275,6 @@ func TestUpdateComputedFields(t *testing.T) {
 			Burial:           types.ObjectNull(event.EventModelAttributeTypes()),
 			CurrentResidence: types.ObjectNull(event.LocationModelAttributeTypes()),
 			About:            types.MapNull(types.StringType),
-			Unions:           planUnions,
 			Projects:         planProjects,
 		}
 
@@ -284,13 +282,11 @@ func TestUpdateComputedFields(t *testing.T) {
 
 		Expect(diags.HasError()).To(BeFalse())
 		Expect(model.ID.ValueString()).To(Equal("profile-123"))
-		// Unions in the plan must survive: the API response passed to
-		// UpdateComputedFields is captured before sibling geni_union
-		// creates/destroys land, so its Unions field is an intermediate
-		// value and must not overwrite the plan (issue #128).
+		// Unions is Computed-only: the live API response is the authoritative
+		// value at Create/Update time (the plan was Unknown).
 		var actualUnions []string
 		Expect(model.Unions.ElementsAs(t.Context(), &actualUnions, false).HasError()).To(BeFalse())
-		Expect(actualUnions).To(ConsistOf("union-from-plan"))
+		Expect(actualUnions).To(ConsistOf("union-1", "union-2"))
 		// Projects in the plan must survive: the API response passed to
 		// UpdateComputedFields is captured before AddProfileToProject runs,
 		// so its Projects field is stale and must not overwrite the plan.

--- a/internal/resource/profile/schema.go
+++ b/internal/resource/profile/schema.go
@@ -97,11 +97,9 @@ func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *res
 				Description: "Nested maps of locales to name fields to values.",
 			},
 			"unions": schema.SetAttribute{
-				ElementType:   types.StringType,
-				Computed:      true,
-				Optional:      true,
-				PlanModifiers: []planmodifier.Set{setplanmodifier.UseStateForUnknown()},
-				Description:   "List of union IDs.",
+				ElementType: types.StringType,
+				Computed:    true,
+				Description: "List of union IDs the profile belongs to. Computed from Geni on refresh.",
 			},
 			"projects": schema.SetAttribute{
 				ElementType: types.StringType,


### PR DESCRIPTION
## Summary

Follow-up to #128 / #129.

The \`unions\` attribute on \`geni_profile\` was declared \`Optional+Computed\` with \`UseStateForUnknown\`, but the provider has never sent it to the Geni API (\`RequestFrom\` ignores it and \`geniprofile.Request\` has no \`Unions\` field). \`Optional\` was a schema lie.

\`UseStateForUnknown\` was also the root cause of #128: it pinned the planned set to the stale prior-state value while sibling \`geni_union\` creates/destroys churned, guaranteeing a plan/actual mismatch unless the provider also wrote the planned value into state (the #129 workaround).

This change:
- Drops \`Optional\` and \`UseStateForUnknown\` from the \`unions\` schema entry — now Computed-only, matching the datasource.
- Restores the live API write-back in \`UpdateComputedFields\` (legal because the planned value is Unknown, so Terraform's post-apply consistency check cannot fire).
- Updates the doc string and regenerates \`docs/resources/profile.md\` — \`unions\` moves from Optional to Read-Only.

**Breaking change** (documented in CHANGELOG): any HCL setting \`unions = [...]\` must be removed. It was always a no-op.

\`projects\` is **not** changed — it is structurally different (\`Optional\` only, no \`Computed\`, genuinely written via \`Project().AddProfile\` side channel in Create/Update) and is correct as-is.

## Test plan

- [x] \`go test -v ./internal/resource/profile/ -run TestUpdateComputedFields\` — inverted assertion (live API value now overwrites the plan); red before fix, green after.
- [x] \`go test ./...\` — full unit suite green.
- [x] \`make docs\` — diff confined to \`docs/resources/profile.md\` (Optional → Read-Only).
- [ ] Real-world: re-run the Журавкино consolidation \`terraform apply\` and confirm no \`inconsistent result\` errors; \`unions = (known after apply)\` appears in the plan.