### PR TITLE
fix: retry transient Geni 5xx instead of aborting the plan (#136)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## 0.23.1 (Unreleased)
 
+BUG FIXES:
+
+* Bump `github.com/dmalch/go-geni` to v1.21.1: transient Geni `502`/`503`/`504`
+  responses (the "Geni Will Be Right Back!" maintenance page) are now retried
+  with backoff instead of aborting the operation on the first attempt, and
+  error output no longer dumps the full HTML body. A brief Geni
+  maintenance/instability window during `terraform plan`/refresh no longer
+  fails the whole plan. (#136)
+
 ## 0.23.0
 
 BREAKING CHANGES:

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26
 
 require (
 	github.com/allegro/bigcache/v3 v3.1.0
-	github.com/dmalch/go-geni v1.20.0
+	github.com/dmalch/go-geni v1.21.1
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/hashicorp/terraform-plugin-go v0.31.0

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dmalch/go-geni v1.20.0 h1:PnLZkGwUwW/F2yd6ZaCEYB8bLIqTLwjhO6sSISiLyGA=
-github.com/dmalch/go-geni v1.20.0/go.mod h1:0ek9/rXCdoYgmUZDkfJxBIRMVGueYuEpv0E0FROmWCw=
+github.com/dmalch/go-geni v1.21.1 h1:iSabhKbWSR69Zzut4XVuTcnOs1gbyzQ9ACAQhjI8WAc=
+github.com/dmalch/go-geni v1.21.1/go.mod h1:0ek9/rXCdoYgmUZDkfJxBIRMVGueYuEpv0E0FROmWCw=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=


### PR DESCRIPTION
## Summary

Fixes #136. During `terraform plan`/refresh, a transient Geni **502/503 "Geni Will Be Right Back!" maintenance page** aborted the entire plan instead of retrying, and dumped the full HTML body into every per-resource error.

Root cause was in the **go-geni** client: `transport/client.go` → `translateStatusError` mapped only `429`/`401` to the retryable `errRetry` sentinel; `502`/`503`/`504` fell through to a generic non-retryable error, so retry-go's `RetryIf` returned `false` (`All attempts fail: #1`).

## Changes

- Bump `github.com/dmalch/go-geni` to **v1.21.1**, which:
  - retries transient `502`/`503`/`504` with backoff, same family as `429`/`401`;
  - truncates the non-OK fallback body (first 512 bytes) so an HTML maintenance page no longer floods error output.
- CHANGELOG entry under `0.23.1 (Unreleased)`.

No provider Go code change is needed — it surfaces whatever go-geni returns.

## Testing

- go-geni: new `TestTranslateStatusError` (502/503/504 → `errRetry`; oversized body summarized; 429/401/403/404/Incapsula regression guards). `make check` green (incl. acceptance).
- provider: `go build ./...` + `go test ./internal/...` pass; `make docs` produces no diff.