### PR TITLE
fix(profile,union): tolerate Geni merges on apply (#134, #138)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 ## 0.23.2 (Unreleased)
 
+BUG FIXES:
+
+* `resource/geni_profile`: an in-place update no longer fails with "Provider
+  produced inconsistent result after apply" on `created_at` when the profile's
+  `created_at` changed on Geni out-of-band — for example after the profile
+  absorbed a duplicate via a Geni merge, where the survivor inherits the older
+  `created_at`. The planned (state-pinned) value is now preserved on Update, and
+  the server value is reconciled into state on the next refresh. (#134)
+
+* `resource/geni_union`: adding partners or children is now idempotent on apply.
+  When Geni has already auto-merged the duplicate union server-side (identical
+  partner set), the provider previously re-added an edge that already existed,
+  failed with "access denied", and tainted the resource — forcing a spurious
+  destroy/recreate and a manual `terraform untaint`. The provider now reads the
+  union's live membership first, skips edges that already exist, and remaps to
+  the surviving canonical union when the tracked union was absorbed. (#138)
+
 ## 0.23.1
 
 BUG FIXES:

--- a/internal/resource/profile/convert.go
+++ b/internal/resource/profile/convert.go
@@ -319,7 +319,16 @@ func UpdateComputedFields(ctx context.Context, profile *geniprofile.Profile, pro
 
 	profileModel.Deleted = types.BoolValue(profile.Deleted)
 	profileModel.MergedInto = types.StringValue(profile.MergedInto)
-	profileModel.CreatedAt = types.StringValue(profile.CreatedAt)
+
+	// created_at is pinned to the prior state value by UseStateForUnknown, so on
+	// Update the plan carries a known value. A Geni merge makes the survivor
+	// inherit a different (older) created_at; overwriting the planned value here
+	// would violate Terraform's plan/apply consistency contract (#134). Only
+	// adopt the server value when the plan left it unset (Create); the next Read
+	// reconciles any server-side change into state.
+	if profileModel.CreatedAt.IsNull() || profileModel.CreatedAt.IsUnknown() {
+		profileModel.CreatedAt = types.StringValue(profile.CreatedAt)
+	}
 
 	return d
 }

--- a/internal/resource/profile/convert_test.go
+++ b/internal/resource/profile/convert_test.go
@@ -301,6 +301,62 @@ func TestUpdateComputedFields(t *testing.T) {
 		Expect(model.About.ElementsAs(t.Context(), &actualAbout, false).HasError()).To(BeFalse())
 		Expect(actualAbout).To(HaveKeyWithValue("en-US", "Updated about"))
 	})
+
+	t.Run("Preserves a known created_at when the API returns a different value (Geni merge)", func(t *testing.T) {
+		RegisterTestingT(t)
+		// A Geni merge makes the survivor inherit the older created_at. The plan
+		// pins created_at to the prior state value via UseStateForUnknown, so on
+		// Update the model already carries a known value. UpdateComputedFields
+		// must not overwrite it with the server value, or Terraform reports
+		// "inconsistent result after apply" on .created_at (#134). The next Read
+		// reconciles the server value into state.
+		givenProfile := &geniprofile.Profile{
+			ID:        "profile-123",
+			CreatedAt: "1779831386", // older value the survivor inherited on merge
+		}
+
+		model := &ResourceModel{
+			Birth:            types.ObjectNull(event.EventModelAttributeTypes()),
+			Baptism:          types.ObjectNull(event.EventModelAttributeTypes()),
+			Death:            types.ObjectNull(event.EventModelAttributeTypes()),
+			Burial:           types.ObjectNull(event.EventModelAttributeTypes()),
+			CurrentResidence: types.ObjectNull(event.LocationModelAttributeTypes()),
+			About:            types.MapNull(types.StringType),
+			Projects:         types.SetNull(types.StringType),
+			CreatedAt:        types.StringValue("1779831518"), // value pinned from prior state
+		}
+
+		diags := UpdateComputedFields(t.Context(), givenProfile, model)
+
+		Expect(diags.HasError()).To(BeFalse())
+		Expect(model.CreatedAt.ValueString()).To(Equal("1779831518"))
+	})
+
+	t.Run("Adopts created_at from the API when the plan value is unknown (Create)", func(t *testing.T) {
+		RegisterTestingT(t)
+		// On Create the plan's created_at is Unknown (UseStateForUnknown yields
+		// unknown with no prior state), so the server value must be adopted.
+		givenProfile := &geniprofile.Profile{
+			ID:        "profile-123",
+			CreatedAt: "1719709400",
+		}
+
+		model := &ResourceModel{
+			Birth:            types.ObjectNull(event.EventModelAttributeTypes()),
+			Baptism:          types.ObjectNull(event.EventModelAttributeTypes()),
+			Death:            types.ObjectNull(event.EventModelAttributeTypes()),
+			Burial:           types.ObjectNull(event.EventModelAttributeTypes()),
+			CurrentResidence: types.ObjectNull(event.LocationModelAttributeTypes()),
+			About:            types.MapNull(types.StringType),
+			Projects:         types.SetNull(types.StringType),
+			CreatedAt:        types.StringUnknown(),
+		}
+
+		diags := UpdateComputedFields(t.Context(), givenProfile, model)
+
+		Expect(diags.HasError()).To(BeFalse())
+		Expect(model.CreatedAt.ValueString()).To(Equal("1719709400"))
+	})
 }
 
 func TestNameElementsFrom(t *testing.T) {

--- a/internal/resource/union/create.go
+++ b/internal/resource/union/create.go
@@ -3,6 +3,7 @@ package union
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 
@@ -77,6 +78,14 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 	adoptedSet := tfset.Index(adoptedIds)
 
 	if len(allChildrenIds) > 0 {
+		// When the union already exists, fetch its live membership once so a
+		// child that Geni already migrated onto it (e.g. via an auto-merge of a
+		// duplicate union) is skipped instead of re-added — a redundant add fails
+		// with "access denied" and taints the resource (#138).
+		var liveResolvedID string
+		var liveChildren map[string]struct{}
+		membersFetched := false
+
 		var skipNextIteration bool
 		for i, childId := range allChildrenIds {
 			if skipNextIteration {
@@ -95,8 +104,21 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 			switch {
 			case !plan.ID.IsUnknown() && !plan.ID.IsNull():
 				// The union already exists — add the child to it.
+				if !membersFetched {
+					var diags diag.Diagnostics
+					liveResolvedID, _, liveChildren, diags = r.currentUnionMembers(ctx, plan.ID.ValueString(), plan.Partners)
+					resp.Diagnostics.Append(diags...)
+					if resp.Diagnostics.HasError() {
+						return
+					}
+					membersFetched = true
+				}
+				if _, ok := liveChildren[childId]; ok {
+					// Already a child of the live union — nothing to add.
+					continue
+				}
 				tmpProfile, err = r.addAndMerge(ctx, childId, func(ctx context.Context) (*geniprofile.Profile, error) {
-					return r.client.Union().AddChild(ctx, plan.ID.ValueString(), geniprofile.WithModifier(modifier))
+					return r.client.Union().AddChild(ctx, liveResolvedID, geniprofile.WithModifier(modifier))
 				})
 			case len(partnerIds) > 0:
 				// When one parent is known, add the child to the parent.

--- a/internal/resource/union/members.go
+++ b/internal/resource/union/members.go
@@ -1,0 +1,77 @@
+package union
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// currentUnionMembers fetches unionId's live membership so callers can add only
+// the edges that are genuinely missing. Geni auto-merges unions with identical
+// partner sets server-side; if the resource's union was absorbed (no partners
+// and no children survive on it), this remaps to the surviving union discovered
+// from the partner set — the same signal Read uses (findExistingUnionForPartners).
+//
+// The returned resolvedID is what add-calls should target. Callers MUST keep
+// their state `id` untouched: rewriting it to resolvedID would violate
+// Terraform's plan/apply consistency contract on `.id` (it is pinned by
+// UseStateForUnknown). The persisted remap is left to the next Read, exactly as
+// it happens today (#138).
+func (r *Resource) currentUnionMembers(ctx context.Context, unionID string, statePartners types.Set) (resolvedID string, partners, children map[string]struct{}, diags diag.Diagnostics) {
+	resolvedID = unionID
+
+	live, err := r.batchClient.GetUnion(ctx, unionID)
+	if err != nil {
+		diags.AddError("Error reading union", err.Error())
+		return resolvedID, nil, nil, diags
+	}
+
+	// The union was auto-merged away — find the surviving canonical union from
+	// the partner set and target that for the add-calls instead.
+	if len(live.Partners) == 0 && len(live.Children) == 0 {
+		canonicalID, d := r.findExistingUnionForPartners(ctx, statePartners)
+		diags.Append(d...)
+		if diags.HasError() {
+			return resolvedID, nil, nil, diags
+		}
+
+		if canonicalID != "" && canonicalID != unionID {
+			diags.AddWarning("Found existing union",
+				"The union in the state has no partners and children. Adding members to the existing union with ID "+canonicalID+" instead.")
+			resolvedID = canonicalID
+			live, err = r.client.Union().Get(ctx, canonicalID)
+			if err != nil {
+				diags.AddError("Error reading union", err.Error())
+				return resolvedID, nil, nil, diags
+			}
+		}
+	}
+
+	partners = make(map[string]struct{}, len(live.Partners))
+	for _, p := range live.Partners {
+		partners[p] = struct{}{}
+	}
+
+	// Geni reports every child (biological, foster, adopted) in Children, with
+	// FosterChildren/AdoptedChildren as labelled subsets, so Children alone is
+	// the complete add-target set.
+	children = make(map[string]struct{}, len(live.Children))
+	for _, c := range live.Children {
+		children[c] = struct{}{}
+	}
+
+	return resolvedID, partners, children, diags
+}
+
+// missingEdges returns the planned ids that are not already present in current,
+// preserving the order of planned.
+func missingEdges(planned []string, current map[string]struct{}) []string {
+	var missing []string
+	for _, id := range planned {
+		if _, ok := current[id]; !ok {
+			missing = append(missing, id)
+		}
+	}
+	return missing
+}

--- a/internal/resource/union/members_test.go
+++ b/internal/resource/union/members_test.go
@@ -1,0 +1,44 @@
+package union
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestMissingEdges(t *testing.T) {
+	t.Run("Returns only the planned ids not already present", func(t *testing.T) {
+		RegisterTestingT(t)
+
+		current := map[string]struct{}{"profile-1": {}, "profile-2": {}}
+		planned := []string{"profile-1", "profile-2", "profile-3"}
+
+		Expect(missingEdges(planned, current)).To(Equal([]string{"profile-3"}))
+	})
+
+	t.Run("Returns empty when every planned id is already present", func(t *testing.T) {
+		RegisterTestingT(t)
+
+		current := map[string]struct{}{"profile-1": {}, "profile-2": {}}
+		planned := []string{"profile-1", "profile-2"}
+
+		Expect(missingEdges(planned, current)).To(BeEmpty())
+	})
+
+	t.Run("Returns all planned ids when none are present", func(t *testing.T) {
+		RegisterTestingT(t)
+
+		planned := []string{"profile-1", "profile-2"}
+
+		Expect(missingEdges(planned, map[string]struct{}{})).To(Equal([]string{"profile-1", "profile-2"}))
+	})
+
+	t.Run("Preserves the order of the planned ids", func(t *testing.T) {
+		RegisterTestingT(t)
+
+		current := map[string]struct{}{"profile-2": {}}
+		planned := []string{"profile-3", "profile-2", "profile-1"}
+
+		Expect(missingEdges(planned, current)).To(Equal([]string{"profile-3", "profile-1"}))
+	})
+}

--- a/internal/resource/union/update.go
+++ b/internal/resource/union/update.go
@@ -3,6 +3,7 @@ package union
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 
@@ -31,8 +32,30 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		}
 	}
 
+	partnersChanged := !plan.Partners.Equal(state.Partners)
+	childrenChanged := !plan.Children.Equal(state.Children) ||
+		!plan.FosterChildren.Equal(state.FosterChildren) ||
+		!plan.AdoptedChildren.Equal(state.AdoptedChildren)
+
+	// Fetch the live union membership once so edge-adds stay idempotent: Geni
+	// may have auto-merged the canonical union (and migrated children onto it)
+	// out-of-band, so re-adding an edge that already exists returns "access
+	// denied" and taints the resource (#138). resolvedID is the union to target
+	// for add-calls — possibly remapped to the surviving union — while plan.ID
+	// in state is left untouched for the next Read to reconcile.
+	var resolvedID string
+	var livePartners, liveChildren map[string]struct{}
+	if partnersChanged || childrenChanged {
+		var diags diag.Diagnostics
+		resolvedID, livePartners, liveChildren, diags = r.currentUnionMembers(ctx, plan.ID.ValueString(), state.Partners)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	// Check if parents were updated
-	if !plan.Partners.Equal(state.Partners) {
+	if partnersChanged {
 		planPartnerIds, diags := tfset.Strings(ctx, plan.Partners)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
@@ -58,11 +81,17 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		for _, partnerId := range planPartnerIds {
 			// If the partner is not in the state, we need to add it
 			if _, ok := knownStatePartnerIds[partnerId]; !ok {
+				// Skip partners already present on the live union (e.g. Geni
+				// auto-merged it onto the canonical union); re-adding would fail
+				// with "access denied" and taint the resource (#138).
+				if _, ok := livePartners[partnerId]; ok {
+					continue
+				}
 				// It is impossible to add an existing profile to a union using the
 				// API, so create a temporary profile and merge it with the existing
 				// one. addAndMerge deletes the temp profile if the merge fails.
 				if _, err := r.addAndMerge(ctx, partnerId, func(ctx context.Context) (*geniprofile.Profile, error) {
-					return r.client.Union().AddPartner(ctx, plan.ID.ValueString())
+					return r.client.Union().AddPartner(ctx, resolvedID)
 				}); err != nil {
 					resp.Diagnostics.AddAttributeError(path.Root(fieldPartners), "Error adding partner", err.Error())
 					return
@@ -81,10 +110,7 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 	}
 
 	// Check if any of the three child sets were updated
-	if !plan.Children.Equal(state.Children) ||
-		!plan.FosterChildren.Equal(state.FosterChildren) ||
-		!plan.AdoptedChildren.Equal(state.AdoptedChildren) {
-
+	if childrenChanged {
 		planBio, diags := tfset.Strings(ctx, plan.Children)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
@@ -137,12 +163,19 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		for _, childId := range planAll {
 			// If the child is not in the state, we need to add it
 			if _, ok := knownStateAll[childId]; !ok {
+				// Skip children already present on the live union (e.g. Geni
+				// auto-merged it onto the canonical union and migrated the child);
+				// re-adding would fail with "access denied" and taint the
+				// resource (#138).
+				if _, ok := liveChildren[childId]; ok {
+					continue
+				}
 				// It is impossible to add an existing profile to a union using the
 				// API, so create a temporary profile and merge it with the existing
 				// one. addAndMerge deletes the temp profile if the merge fails.
 				modifier := modifierFor(childId, fosterSet, adoptedSet)
 				if _, err := r.addAndMerge(ctx, childId, func(ctx context.Context) (*geniprofile.Profile, error) {
-					return r.client.Union().AddChild(ctx, plan.ID.ValueString(), geniprofile.WithModifier(modifier))
+					return r.client.Union().AddChild(ctx, resolvedID, geniprofile.WithModifier(modifier))
 				}); err != nil {
 					resp.Diagnostics.AddAttributeError(path.Root(fieldChildren), "Error adding child with ID="+childId, err.Error())
 					return


### PR DESCRIPTION
## Summary

Two consolidation-`apply` failures caused by out-of-band Geni merges. Both abort
the apply mid-run and require a manual second pass / `terraform untaint`.

### #134 — `geni_profile.created_at` "inconsistent result after apply"

`created_at` is `Computed+Optional` with `UseStateForUnknown()`, so the plan pins it
to the prior state value. After a Geni **profile merge** the survivor inherits the
*older* `created_at`, but `UpdateComputedFields` unconditionally overwrote the model
with the server value on Update → planned (known) value ≠ applied value → hard error.

**Fix:** only adopt the server `created_at` when the plan left it unset (Create);
preserve the plan-pinned value on Update. The server value is reconciled into state
on the next refresh via `ValueFrom`. This mirrors the conditional pattern `document`
and `photo` already use. Schema unchanged.

### #138 — `geni_union` taints when Geni auto-merges a duplicate union

When Geni auto-merges a duplicate union server-side (identical partner set), the
provider re-added an edge that already existed, got `access denied`, and Terraform
tainted the resource → spurious `-/+ replace` + manual `terraform untaint`.

**Fix:** new `currentUnionMembers` helper reads the union's live membership and, if
the tracked union was absorbed, remaps to the surviving canonical union (reusing the
Read-side `findExistingUnionForPartners`). Create/Update now skip edges already
present and target the resolved union id for adds. Crucially `plan.ID` in state is
**not** rewritten — that would re-trigger an `inconsistent result` on `.id` (pinned by
`UseStateForUnknown`); the persisted remap is left to the next Read, as today. Genuine
403s on truly-missing edges still surface as errors (no swallowing of `ErrAccessDenied`).

## Tests

- TDD: unit tests written first (RED→GREEN).
  - `TestUpdateComputedFields`: preserve known `created_at`; adopt when unknown.
  - `TestMissingEdges`: pure edge-diff helper.
- Acceptance (Geni sandbox): 34 relevant tests pass — full `TestAccUnion_*` suite
  (every Create/Update path now routes through the membership pre-check) plus profile
  create/update paths driving `UpdateComputedFields`. `failTo*` tests confirm real
  errors/warnings still fire.
- `make build`, `go test ./...`, `golangci-lint run` (0 issues), `make docs` (no diff).

## Notes

Provider-layer only — no go-geni or schema changes. CHANGELOG updated under
`## 0.23.2 (Unreleased)`.

Closes #134
Closes #138