### PR TITLE
chore(deps): bump go-geni to v1.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,34 @@
-## 0.24.1 (Unreleased)
+## 0.25.0 (Unreleased)
+
+IMPROVEMENTS:
+
+* Upgraded `github.com/dmalch/go-geni` from v1.21.1 to v1.28.0. The provider
+  drives the same browser OAuth handshake and the same
+  `~/.genealogy/geni_token.json` cache as the `geni` CLI, so its fixes land
+  here too:
+  * The OAuth callback listener no longer leaks. It was shut down only when
+    the login succeeded, so Ctrl-C, the five-minute timeout and a state
+    mismatch all left port 8080 held for the life of the process — and a
+    `terraform apply` that had to authenticate after an interrupted one
+    failed on a port its own predecessor was squatting.
+  * A busy callback port is reported before a browser tab opens, rather than
+    after.
+  * The callback binds `127.0.0.1` instead of every interface. It carries an
+    access token in its query string and had no business being reachable from
+    the local network.
+  * A login is no longer rejected outright when Geni's callback omits
+    `expires_in`; the documented 24-hour lifetime is assumed instead of
+    discarding a valid token.
+
+BEHAVIORAL CHANGES:
+
+* The token cache is written with mode `0600` instead of `0644`, through a
+  temporary file and a rename. An existing world-readable cache is replaced on
+  the next login. If something other than your own user account reads
+  `~/.genealogy/geni_token.json`, it will stop being able to.
+* The authorization screen is requested with `display=web` rather than
+  `display=mobile`, so the consent page renders at desktop size. Same redirect
+  target, same parameters — verified against the live API.
 
 ## 0.24.0
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/dmalch/terraform-provider-genealogy
 go 1.26
 
 require (
-	github.com/dmalch/go-geni v1.21.1
+	github.com/dmalch/go-geni v1.28.0
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/hashicorp/terraform-plugin-go v0.31.0

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dmalch/go-geni v1.21.1 h1:iSabhKbWSR69Zzut4XVuTcnOs1gbyzQ9ACAQhjI8WAc=
-github.com/dmalch/go-geni v1.21.1/go.mod h1:0ek9/rXCdoYgmUZDkfJxBIRMVGueYuEpv0E0FROmWCw=
+github.com/dmalch/go-geni v1.28.0 h1:VIyFvmmT03CIAdZrI3nqr1I4z7YLKcd2xBH98Rj+siY=
+github.com/dmalch/go-geni v1.28.0/go.mod h1:FR7LU3f5Eni4497kkXBljkj+22EfznoAyJi4cMRQc+A=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
@@ -144,8 +144,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/oklog/run v1.2.0 h1:O8x3yXwah4A73hJdlrwo/2X6J62gE5qTMusH0dvz60E=
 github.com/oklog/run v1.2.0/go.mod h1:mgDbKRSwPhJfesJ4PntqFUbKQRZ50NgmZTSPlFA0YFk=
-github.com/onsi/ginkgo/v2 v2.29.0 h1:rfh+ZFjgJhYWRoIqVf3Uwx/W20yLrcrE2h2GmYVRaag=
-github.com/onsi/ginkgo/v2 v2.29.0/go.mod h1:+aXOY+vzZ5mu2iI2HpTZUPmM//oQfsNFX6gU9kNcA44=
+github.com/onsi/ginkgo/v2 v2.32.0 h1:Hw7s2pVrQo/8Yz5N77qdnpHaoc+c6cC9WIV1Jce+J6E=
+github.com/onsi/ginkgo/v2 v2.32.0/go.mod h1:+aXOY+vzZ5mu2iI2HpTZUPmM//oQfsNFX6gU9kNcA44=
 github.com/onsi/gomega v1.42.1 h1:iN1rCUX+44NZ1Dc97MPoeFYbFR0vh8zxoxMFwKdyZ6I=
 github.com/onsi/gomega v1.42.1/go.mod h1:REff/hsDsodHoKlWsP2mAPhu1+5/6hVYNf9rIEBpeSg=
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=


### PR DESCRIPTION
The provider drives the same browser OAuth handshake and the same `~/.genealogy/geni_token.json` cache as the `geni` CLI, so the auth work in go-geni 1.22.0–1.28.0 lands here with the bump. No provider schema changes; `make docs` produces no diff.

## What this fixes

- **The OAuth callback listener no longer leaks.** It was shut down only on success, so Ctrl-C, the five-minute timeout and a state mismatch all left port 8080 held for the life of the process. A `terraform apply` that had to authenticate after an interrupted one failed on a port its own predecessor was squatting.
- A busy callback port is reported **before** a browser tab opens, rather than after — `ListenAndServe` surfaces `EADDRINUSE` asynchronously.
- The callback binds `127.0.0.1` instead of every interface. It carries an access token in its query string.
- A login is no longer rejected outright when Geni's callback omits `expires_in`; the documented 24-hour lifetime is assumed instead of discarding a valid token.

## Behavioral changes

- **Token cache is now `0600`**, written through a rename. An existing world-readable cache is replaced on the next login. If anything other than your own user account reads `~/.genealogy/geni_token.json`, it will stop being able to.
- **`display=web` instead of `display=mobile`** — the consent page renders at desktop size. Same redirect target, same query parameters, verified against the live API.

## Compatibility

Source-compatible: `auth.NewAuthTokenSource` took its new options variadically and `auth.NewCachingTokenSource` is unchanged, so no call site moved. The cache gains `token_type` (and `refresh_token` if written by a CLI configured for the server-side flow) — both standard `oauth2.Token` fields, so this provider reads such a cache without complaint.

## Not included

go-geni 1.28.0 added Geni's server-side flow, which returns a **refresh token** and ends the daily browser round trip. Wiring it up here needs a client secret in the provider configuration, so it is a deliberate follow-up rather than part of a dependency bump.

## Verification

`make test` (238 passing), `make lint` (0 issues), `make docs` (no diff), `go build ./...`.