### PR TITLE
feat: log in once, not once a day

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,36 @@
-## 0.25.1 (Unreleased)
+## 0.26.0 (Unreleased)
+
+FEATURES:
+
+* The provider can now log in **once** instead of once a day. Geni's access
+  tokens last 24 hours and the browser flow the provider has always used
+  returns nothing to renew them with, so a `terraform apply` on a new day
+  opened a browser. Supplying the OAuth application's client secret switches
+  the login to Geni's server-side flow, which returns a refresh token; the
+  provider then renews in the background and writes the result back to
+  `~/.genealogy/geni_token.json`. Without a secret nothing changes.
+
+  Two new provider attributes, `client_secret` (sensitive) and `client_id`,
+  resolved in descending precedence:
+
+  1. `GENI_CLIENT_SECRET` / `GENI_CLIENT_ID` (`GENI_SANDBOX_*` under the
+     sandbox environment);
+  2. the `provider "geni"` block;
+  3. `~/.genealogy/config.json`, written by `geni config client-secret` in the
+     [geni CLI](https://github.com/dmalch/go-geni) — so one command configures
+     both tools, the way they already share a token cache.
+
+  The id travels with the secret at each level: a level that supplies only a
+  secret keeps the built-in application id, and a level that supplies only an
+  id never picks up a secret belonging to a different application. Prefer the
+  environment variable or the CLI config over the provider block — a secret in
+  a `.tf` file tends to end up in version control.
+
+  Getting a secret: your application's page under
+  [Geni developer apps](https://www.geni.com/platform/developer/apps).
+  Renewal is best-effort — if Geni rejects the stored refresh token the
+  provider falls back to the browser, and if Geni is merely unreachable it
+  reports that rather than opening one.
 
 ## 0.25.0
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,4 +18,6 @@ This provider enables managing data on Geni.com through Terraform. It exposes co
 
 - `access_token` (String, Sensitive) The Access Token for the Geni API. Can also be set with the GENI_ACCESS_TOKEN environment variable. If not provided, the provider will attempt to do a browser-based OAuth login flow.
 - `auto_update_merged_profiles` (Boolean) Whether to automatically update merged profiles in the state
+- `client_id` (String) The OAuth client id of your own registered Geni application, if you do not want to use the built-in one. Can also be set with the GENI_CLIENT_ID environment variable (GENI_SANDBOX_CLIENT_ID under the sandbox environment). Supply it together with `client_secret`.
+- `client_secret` (String, Sensitive) The OAuth client secret of the Geni application. Supplying it switches the browser login to Geni's server-side flow, which returns a refresh token, so the provider renews the token in the background instead of opening a browser every 24 hours. Can also be set with the GENI_CLIENT_SECRET environment variable (GENI_SANDBOX_CLIENT_SECRET under the sandbox environment), or with `geni config client-secret` in the geni CLI, which stores it in ~/.genealogy/config.json alongside the shared token cache.
 - `use_sandbox_env` (Boolean) Whether to use the Geni Sandbox environment. Can also be set with the GENI_USE_SANDBOX environment variable.

--- a/internal/config/provider_config.go
+++ b/internal/config/provider_config.go
@@ -9,6 +9,8 @@ import (
 
 type GeniProviderConfig struct {
 	AccessToken              types.String `tfsdk:"access_token"`
+	ClientID                 types.String `tfsdk:"client_id"`
+	ClientSecret             types.String `tfsdk:"client_secret"`
 	UseSandboxEnv            types.Bool   `tfsdk:"use_sandbox_env"`
 	AutoUpdateMergedProfiles types.Bool   `tfsdk:"auto_update_merged_profiles"`
 }

--- a/internal/geniapp/app.go
+++ b/internal/geniapp/app.go
@@ -1,0 +1,141 @@
+// Package geniapp resolves the registered Geni OAuth application the
+// provider authenticates as.
+//
+// A client secret is what unlocks Geni's server-side flow, which returns a
+// refresh token; without one the provider falls back to the client-side
+// flow and its browser round trip every 24 hours.
+package geniapp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// Built-in application ids, used when the caller does not bring their own.
+const (
+	prodClientID    = "1855"
+	sandboxClientID = "8"
+)
+
+// Credentials identify a registered Geni application.
+type Credentials struct {
+	ClientID     string
+	ClientSecret string
+}
+
+// Refreshable reports whether these credentials can drive the
+// server-side flow.
+func (c Credentials) Refreshable() bool {
+	return c.ClientSecret != ""
+}
+
+// Explicit is what the practitioner wrote in the provider block. Empty
+// strings mean "not set".
+type Explicit struct {
+	ClientID     string
+	ClientSecret string
+}
+
+// Resolve picks the application to authenticate as, in descending
+// precedence:
+//
+//  1. the GENI_CLIENT_ID / GENI_CLIENT_SECRET environment variables
+//     (GENI_SANDBOX_* under the sandbox environment);
+//  2. the provider configuration block;
+//  3. ~/.genealogy/config.json, which the geni CLI writes — so
+//     "geni config client-secret" configures both tools at once, the way
+//     they already share a token cache.
+//
+// The id travels with the secret at each level: the secret for the
+// built-in application belongs to its owner, so anyone else registers
+// their own application and supplies both halves. A level that carries
+// only a secret keeps the built-in id.
+//
+// Resolving never fails on an unreadable config file. The worst case is
+// the behavior of every release before this one — an interactive login.
+func Resolve(explicit Explicit, useSandboxEnv bool) Credentials {
+	for _, candidate := range []Credentials{
+		fromEnvironment(useSandboxEnv),
+		{ClientID: explicit.ClientID, ClientSecret: explicit.ClientSecret},
+		fromCLIConfig(useSandboxEnv),
+	} {
+		if candidate.ClientID == "" && candidate.ClientSecret == "" {
+			continue
+		}
+		if candidate.ClientID == "" {
+			candidate.ClientID = DefaultClientID(useSandboxEnv)
+		}
+		return candidate
+	}
+	return Credentials{ClientID: DefaultClientID(useSandboxEnv)}
+}
+
+// DefaultClientID returns the built-in application id for the
+// environment.
+func DefaultClientID(useSandboxEnv bool) string {
+	if useSandboxEnv {
+		return sandboxClientID
+	}
+	return prodClientID
+}
+
+func fromEnvironment(useSandboxEnv bool) Credentials {
+	idVar, secretVar := "GENI_CLIENT_ID", "GENI_CLIENT_SECRET"
+	if useSandboxEnv {
+		idVar, secretVar = "GENI_SANDBOX_CLIENT_ID", "GENI_SANDBOX_CLIENT_SECRET"
+	}
+	return Credentials{
+		ClientID:     os.Getenv(idVar),
+		ClientSecret: os.Getenv(secretVar),
+	}
+}
+
+// cliConfig is the part of the geni CLI's ~/.genealogy/config.json this
+// provider cares about. The file belongs to the CLI; unknown fields are
+// ignored, and a format change there costs nothing worse here than
+// falling back to an interactive login.
+type cliConfig struct {
+	Prod    cliOAuthApp `json:"prod"`
+	Sandbox cliOAuthApp `json:"sandbox"`
+}
+
+type cliOAuthApp struct {
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+}
+
+func fromCLIConfig(useSandboxEnv bool) Credentials {
+	path, err := ConfigFilePath()
+	if err != nil {
+		return Credentials{}
+	}
+
+	// A missing or unreadable file is not an error worth a diagnostic:
+	// the login still works, it just asks for a browser.
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return Credentials{}
+	}
+
+	var c cliConfig
+	if err := json.Unmarshal(body, &c); err != nil {
+		return Credentials{}
+	}
+
+	app := c.Prod
+	if useSandboxEnv {
+		app = c.Sandbox
+	}
+	return Credentials(app)
+}
+
+// ConfigFilePath returns the geni CLI's configuration file, which lives
+// beside the token cache the two tools share.
+func ConfigFilePath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".genealogy", "config.json"), nil
+}

--- a/internal/geniapp/app_test.go
+++ b/internal/geniapp/app_test.go
@@ -1,0 +1,165 @@
+package geniapp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+// isolate points HOME at an empty directory and clears every variable
+// Resolve consults, so a developer's own exports cannot decide a test.
+func isolate(t *testing.T) {
+	t.Helper()
+
+	t.Setenv("HOME", t.TempDir())
+	for _, name := range []string{
+		"GENI_CLIENT_ID", "GENI_CLIENT_SECRET",
+		"GENI_SANDBOX_CLIENT_ID", "GENI_SANDBOX_CLIENT_SECRET",
+	} {
+		t.Setenv(name, "")
+	}
+}
+
+// writeCLIConfig plants the file the geni CLI writes.
+func writeCLIConfig(t *testing.T, body any) {
+	t.Helper()
+
+	path, err := ConfigFilePath()
+	if err != nil {
+		t.Fatalf("failed to build the config path: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("failed to create the config directory: %v", err)
+	}
+
+	var encoded []byte
+	switch v := body.(type) {
+	case string:
+		encoded = []byte(v)
+	default:
+		encoded, err = json.Marshal(v)
+		if err != nil {
+			t.Fatalf("failed to encode the config: %v", err)
+		}
+	}
+	if err := os.WriteFile(path, encoded, 0o600); err != nil {
+		t.Fatalf("failed to write the config: %v", err)
+	}
+}
+
+func TestResolve(t *testing.T) {
+	t.Run("Falls back to the built-in application with no secret", func(t *testing.T) {
+		RegisterTestingT(t)
+		isolate(t)
+
+		app := Resolve(Explicit{}, false)
+		Expect(app.ClientID).To(Equal("1855"))
+		Expect(app.ClientSecret).To(BeEmpty())
+		Expect(app.Refreshable()).To(BeFalse())
+	})
+
+	t.Run("Reads the environment first", func(t *testing.T) {
+		RegisterTestingT(t)
+		isolate(t)
+		writeCLIConfig(t, cliConfig{Prod: cliOAuthApp{ClientID: "cfg", ClientSecret: "cfg-secret"}})
+		t.Setenv("GENI_CLIENT_ID", "env")
+		t.Setenv("GENI_CLIENT_SECRET", "env-secret")
+
+		app := Resolve(Explicit{ClientID: "hcl", ClientSecret: "hcl-secret"}, false)
+		Expect(app.ClientID).To(Equal("env"))
+		Expect(app.ClientSecret).To(Equal("env-secret"))
+	})
+
+	t.Run("Prefers the provider block over the CLI config", func(t *testing.T) {
+		RegisterTestingT(t)
+		isolate(t)
+		writeCLIConfig(t, cliConfig{Prod: cliOAuthApp{ClientID: "cfg", ClientSecret: "cfg-secret"}})
+
+		app := Resolve(Explicit{ClientID: "hcl", ClientSecret: "hcl-secret"}, false)
+		Expect(app.ClientID).To(Equal("hcl"))
+		Expect(app.ClientSecret).To(Equal("hcl-secret"))
+	})
+
+	// The point of reading the CLI's file: "geni config client-secret"
+	// configures both tools, the way they already share a token cache.
+	t.Run("Falls back to the secret stored by the geni CLI", func(t *testing.T) {
+		RegisterTestingT(t)
+		isolate(t)
+		writeCLIConfig(t, cliConfig{Prod: cliOAuthApp{ClientSecret: "cfg-secret"}})
+
+		app := Resolve(Explicit{}, false)
+		Expect(app.ClientID).To(Equal("1855"))
+		Expect(app.ClientSecret).To(Equal("cfg-secret"))
+		Expect(app.Refreshable()).To(BeTrue())
+	})
+
+	// A secret alone is enough, and keeps the built-in id: that is the
+	// case for whoever owns the built-in application.
+	t.Run("Keeps the built-in id when only a secret is supplied", func(t *testing.T) {
+		RegisterTestingT(t)
+		isolate(t)
+
+		app := Resolve(Explicit{ClientSecret: "hcl-secret"}, false)
+		Expect(app.ClientID).To(Equal("1855"))
+		Expect(app.ClientSecret).To(Equal("hcl-secret"))
+	})
+
+	// The id travels with the secret: a level that sets an id must not
+	// pick up a secret belonging to a different application.
+	t.Run("Never mixes an id from one level with a secret from another", func(t *testing.T) {
+		RegisterTestingT(t)
+		isolate(t)
+		writeCLIConfig(t, cliConfig{Prod: cliOAuthApp{ClientID: "cfg", ClientSecret: "cfg-secret"}})
+
+		app := Resolve(Explicit{ClientID: "hcl"}, false)
+		Expect(app.ClientID).To(Equal("hcl"))
+		Expect(app.ClientSecret).To(BeEmpty())
+	})
+
+	t.Run("Keeps the environments apart", func(t *testing.T) {
+		RegisterTestingT(t)
+		isolate(t)
+		writeCLIConfig(t, cliConfig{
+			Prod:    cliOAuthApp{ClientSecret: "prod-secret"},
+			Sandbox: cliOAuthApp{ClientSecret: "sandbox-secret"},
+		})
+
+		Expect(Resolve(Explicit{}, false).ClientSecret).To(Equal("prod-secret"))
+
+		sandbox := Resolve(Explicit{}, true)
+		Expect(sandbox.ClientID).To(Equal("8"))
+		Expect(sandbox.ClientSecret).To(Equal("sandbox-secret"))
+	})
+
+	t.Run("Reads the sandbox environment variables under the sandbox", func(t *testing.T) {
+		RegisterTestingT(t)
+		isolate(t)
+		t.Setenv("GENI_CLIENT_SECRET", "prod-secret")
+		t.Setenv("GENI_SANDBOX_CLIENT_SECRET", "sandbox-secret")
+
+		Expect(Resolve(Explicit{}, true).ClientSecret).To(Equal("sandbox-secret"))
+		Expect(Resolve(Explicit{}, false).ClientSecret).To(Equal("prod-secret"))
+	})
+
+	// The config file belongs to the CLI. If it ever changes shape, the
+	// worst this may cost is the behavior of every earlier release.
+	t.Run("Falls back to an interactive login when the CLI config is unreadable", func(t *testing.T) {
+		RegisterTestingT(t)
+		isolate(t)
+		writeCLIConfig(t, "{ not json")
+
+		app := Resolve(Explicit{}, false)
+		Expect(app.ClientID).To(Equal("1855"))
+		Expect(app.Refreshable()).To(BeFalse())
+	})
+}
+
+func TestDefaultClientID(t *testing.T) {
+	RegisterTestingT(t)
+
+	Expect(DefaultClientID(false)).To(Equal("1855"))
+	Expect(DefaultClientID(true)).To(Equal("8"))
+}

--- a/internal/provider.go
+++ b/internal/provider.go
@@ -19,6 +19,7 @@ import (
 	"github.com/dmalch/terraform-provider-genealogy/internal/config"
 	profiledatasource "github.com/dmalch/terraform-provider-genealogy/internal/datasource/profile"
 	"github.com/dmalch/terraform-provider-genealogy/internal/datasource/project"
+	"github.com/dmalch/terraform-provider-genealogy/internal/geniapp"
 	"github.com/dmalch/terraform-provider-genealogy/internal/genibatch"
 	"github.com/dmalch/terraform-provider-genealogy/internal/resource/document"
 	"github.com/dmalch/terraform-provider-genealogy/internal/resource/photo"
@@ -54,6 +55,15 @@ func (p *GeniProvider) Schema(_ context.Context, _ provider.SchemaRequest, resp 
 				Optional:    true,
 				Sensitive:   true,
 				Description: "The Access Token for the Geni API. Can also be set with the GENI_ACCESS_TOKEN environment variable. If not provided, the provider will attempt to do a browser-based OAuth login flow.",
+			},
+			"client_id": schema.StringAttribute{
+				Optional:    true,
+				Description: "The OAuth client id of your own registered Geni application, if you do not want to use the built-in one. Can also be set with the GENI_CLIENT_ID environment variable (GENI_SANDBOX_CLIENT_ID under the sandbox environment). Supply it together with `client_secret`.",
+			},
+			"client_secret": schema.StringAttribute{
+				Optional:    true,
+				Sensitive:   true,
+				Description: "The OAuth client secret of the Geni application. Supplying it switches the browser login to Geni's server-side flow, which returns a refresh token, so the provider renews the token in the background instead of opening a browser every 24 hours. Can also be set with the GENI_CLIENT_SECRET environment variable (GENI_SANDBOX_CLIENT_SECRET under the sandbox environment), or with `geni config client-secret` in the geni CLI, which stores it in ~/.genealogy/config.json alongside the shared token cache.",
 			},
 			"use_sandbox_env": schema.BoolAttribute{
 				Optional:    true,
@@ -93,15 +103,12 @@ func (p *GeniProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 		return
 	}
 
-	var tokenSource = oauth2.ReuseTokenSource(nil,
-		auth.NewCachingTokenSource(
-			cacheFilePath,
-			auth.NewAuthTokenSource(&oauth2.Config{
-				ClientID: clientId(useSandboxEnv),
-				Endpoint: oauth2.Endpoint{
-					AuthURL: geni.BaseURL(useSandboxEnv) + "platform/oauth/authorize",
-				},
-			})))
+	app := geniapp.Resolve(geniapp.Explicit{
+		ClientID:     cfg.ClientID.ValueString(),
+		ClientSecret: cfg.ClientSecret.ValueString(),
+	}, useSandboxEnv)
+
+	tokenSource := browserTokenSource(app, auth.GeniEndpoint(geni.BaseURL(useSandboxEnv)), cacheFilePath)
 
 	if accessToken != "" {
 		tokenSource = oauth2.StaticTokenSource(&oauth2.Token{AccessToken: accessToken})
@@ -133,6 +140,38 @@ func (p *GeniProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 	}
 }
 
+// browserTokenSource builds the token source behind an interactive
+// login.
+//
+// With a client secret it runs Geni's server-side flow, which returns a
+// refresh token, and renews from it instead of opening a browser once a
+// day. Renewing happens inside the caching source, below
+// oauth2.ReuseTokenSource: Geni rotates the refresh token on every
+// renewal, so a refresher above the cache would renew into memory and
+// lose the new token when Terraform exits — which, for a provider, is
+// after every single command.
+//
+// Without a secret this is the client-side flow the provider has always
+// used, and its 24-hour token.
+// The endpoint is a parameter rather than derived here so a test can
+// stand one up and exercise the refresh without a browser.
+func browserTokenSource(app geniapp.Credentials, endpoint oauth2.Endpoint, cacheFilePath string) oauth2.TokenSource {
+	oauthConfig := &oauth2.Config{
+		ClientID:     app.ClientID,
+		ClientSecret: app.ClientSecret,
+		Endpoint:     endpoint,
+	}
+
+	if !app.Refreshable() {
+		return oauth2.ReuseTokenSource(nil,
+			auth.NewCachingTokenSource(cacheFilePath, auth.NewAuthTokenSource(oauthConfig)))
+	}
+
+	codeSource := auth.NewCodeTokenSource(oauthConfig)
+	return oauth2.ReuseTokenSource(nil,
+		auth.NewRefreshingCachingTokenSource(cacheFilePath, codeSource, codeSource))
+}
+
 func tokenCacheFilePath(useSandboxEnv bool) (string, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
@@ -145,16 +184,6 @@ func tokenCacheFilePath(useSandboxEnv bool) (string, error) {
 	}
 
 	return cacheFilePath, nil
-}
-
-func clientId(useSandboxEnv bool) string {
-	if useSandboxEnv {
-		// Sandbox client ID
-		return "8"
-	}
-
-	// Production client ID
-	return "1855"
 }
 
 func (p *GeniProvider) Resources(_ context.Context) []func() resource.Resource {

--- a/internal/provider_test.go
+++ b/internal/provider_test.go
@@ -1,16 +1,23 @@
 package internal
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"path"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	. "github.com/onsi/gomega"
+	"golang.org/x/oauth2"
 
 	"github.com/dmalch/terraform-provider-genealogy/internal/config"
+	"github.com/dmalch/terraform-provider-genealogy/internal/geniapp"
 )
 
 func TestTokenCacheFilePath(t *testing.T) {
@@ -35,20 +42,6 @@ func TestTokenCacheFilePath(t *testing.T) {
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(result).To(Equal(path.Join(homeDir, ".genealogy", "geni_sandbox_token.json")))
-	})
-}
-
-func TestClientId(t *testing.T) {
-	t.Run("production", func(t *testing.T) {
-		RegisterTestingT(t)
-
-		Expect(clientId(false)).To(Equal("1855"))
-	})
-
-	t.Run("sandbox", func(t *testing.T) {
-		RegisterTestingT(t)
-
-		Expect(clientId(true)).To(Equal("8"))
 	})
 }
 
@@ -106,6 +99,8 @@ func configureProvider(t *testing.T, p *GeniProvider, accessToken string) *provi
 
 	raw := tftypes.NewValue(schemaResp.Schema.Type().TerraformType(ctx), map[string]tftypes.Value{
 		"access_token":                tftypes.NewValue(tftypes.String, accessToken),
+		"client_id":                   tftypes.NewValue(tftypes.String, nil),
+		"client_secret":               tftypes.NewValue(tftypes.String, nil),
 		"use_sandbox_env":             tftypes.NewValue(tftypes.Bool, nil),
 		"auto_update_merged_profiles": tftypes.NewValue(tftypes.Bool, nil),
 	})
@@ -115,4 +110,109 @@ func configureProvider(t *testing.T, p *GeniProvider, accessToken string) *provi
 		Config: tfsdk.Config{Schema: schemaResp.Schema, Raw: raw},
 	}, resp)
 	return resp
+}
+
+// TestBrowserTokenSource covers the reason this provider learned about
+// client secrets: a token that renews itself instead of opening a
+// browser every 24 hours.
+func TestBrowserTokenSource(t *testing.T) {
+	// seedCache writes a token into a fresh cache file and returns its
+	// path.
+	seedCache := func(t *testing.T, token *oauth2.Token) string {
+		t.Helper()
+
+		cachePath := path.Join(t.TempDir(), "geni_token.json")
+		body, err := json.Marshal(token)
+		if err != nil {
+			t.Fatalf("failed to encode the token: %v", err)
+		}
+		if err := os.WriteFile(cachePath, body, 0o600); err != nil {
+			t.Fatalf("failed to seed the token cache: %v", err)
+		}
+		return cachePath
+	}
+
+	// tokenEndpoint stands in for /platform/oauth/request_token.
+	tokenEndpoint := func(t *testing.T, body string) (oauth2.Endpoint, *url.Values) {
+		t.Helper()
+
+		var seen url.Values
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if err := r.ParseForm(); err != nil {
+				t.Errorf("failed to parse the token request: %v", err)
+			}
+			seen = r.PostForm
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(body))
+		}))
+		t.Cleanup(server.Close)
+
+		return oauth2.Endpoint{TokenURL: server.URL, AuthStyle: oauth2.AuthStyleInParams}, &seen
+	}
+
+	// The whole feature in one assertion: an expired token renews from
+	// disk, with no browser involved.
+	t.Run("Renews an expired token from the cached refresh token", func(t *testing.T) {
+		RegisterTestingT(t)
+
+		cachePath := seedCache(t, &oauth2.Token{
+			AccessToken:  "stale",
+			RefreshToken: "stored-rt",
+			Expiry:       time.Now().Add(-time.Hour),
+		})
+		endpoint, seen := tokenEndpoint(t,
+			`{"access_token":"renewed","refresh_token":"rotated-rt","expires_in":86400}`)
+
+		app := geniapp.Credentials{ClientID: "1855", ClientSecret: "app-secret"}
+		token, err := browserTokenSource(app, endpoint, cachePath).Token()
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(token.AccessToken).To(Equal("renewed"))
+		Expect(seen.Get("grant_type")).To(Equal("refresh_token"))
+		Expect(seen.Get("refresh_token")).To(Equal("stored-rt"))
+		Expect(seen.Get("client_secret")).To(Equal("app-secret"))
+	})
+
+	// Geni rotates the refresh token on every renewal, so the new one has
+	// to reach disk — Terraform exits after every command.
+	t.Run("Writes the rotated refresh token back to the cache", func(t *testing.T) {
+		RegisterTestingT(t)
+
+		cachePath := seedCache(t, &oauth2.Token{
+			AccessToken:  "stale",
+			RefreshToken: "stored-rt",
+			Expiry:       time.Now().Add(-time.Hour),
+		})
+		endpoint, _ := tokenEndpoint(t,
+			`{"access_token":"renewed","refresh_token":"rotated-rt","expires_in":86400}`)
+
+		app := geniapp.Credentials{ClientID: "1855", ClientSecret: "app-secret"}
+		_, err := browserTokenSource(app, endpoint, cachePath).Token()
+		Expect(err).ToNot(HaveOccurred())
+
+		body, err := os.ReadFile(cachePath)
+		Expect(err).ToNot(HaveOccurred())
+
+		var stored oauth2.Token
+		Expect(json.Unmarshal(body, &stored)).To(Succeed())
+		Expect(stored.AccessToken).To(Equal("renewed"))
+		Expect(stored.RefreshToken).To(Equal("rotated-rt"))
+	})
+
+	// Without a secret the provider keeps the flow it has always used,
+	// and a cached token is still served straight from disk.
+	t.Run("Serves a valid cached token without a client secret", func(t *testing.T) {
+		RegisterTestingT(t)
+
+		cachePath := seedCache(t, &oauth2.Token{
+			AccessToken: "cached",
+			Expiry:      time.Now().Add(time.Hour),
+		})
+
+		app := geniapp.Credentials{ClientID: "1855"}
+		token, err := browserTokenSource(app, oauth2.Endpoint{}, cachePath).Token()
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(token.AccessToken).To(Equal("cached"))
+	})
 }


### PR DESCRIPTION
Geni's access tokens last 24 hours, and the client-side flow this provider has always used returns nothing to renew them with — so the first `terraform apply` of a new day opened a browser. Geni's **server-side flow** returns a refresh token. A client secret is all it takes to switch.

Without a secret, nothing changes.

## Configuring it

Two new attributes, `client_secret` (sensitive) and `client_id`, resolved in descending precedence:

1. `GENI_CLIENT_SECRET` / `GENI_CLIENT_ID` (`GENI_SANDBOX_*` under the sandbox environment)
2. the `provider "geni"` block
3. `~/.genealogy/config.json`, written by `geni config client-secret` in the [geni CLI](https://github.com/dmalch/go-geni)

The third source is the interesting one. The CLI and this provider already share a token cache, so sharing where the secret lives means **one command configures both**. Prefer the environment variable or the CLI config over the provider block — a secret in a `.tf` file tends to end up in version control.

The id travels with the secret at each level: a level carrying only a secret keeps the built-in application id, and one carrying only an id never picks up a secret belonging to a different application.

## Why the layering is what it is

Renewal happens **inside** the caching token source, below `oauth2.ReuseTokenSource`. Geni rotates the refresh token on every renewal, so a refresher placed above the cache would renew into memory and lose the new token when the process exits — which, for a Terraform provider, is after every single command. `TestBrowserTokenSource` pins exactly that: it asserts the *rotated* refresh token reaches disk, not just that the call succeeded.

A rejected refresh token falls back to the browser. A Geni that is merely unreachable is reported instead — being down is not a reason to open a browser window.

## On reading the CLI's config file

That file belongs to the CLI and there is no contract between the two repos, so this reads it through a local struct and treats anything unreadable as "no secret configured" rather than raising a diagnostic. If the CLI ever changes that format, the worst it costs here is the behavior of every release before this one: an interactive login.

## Verification

Beyond `make test` (250 passing), `make lint` (0 issues) and `make docs` (regenerated), the feature was exercised end to end against **production Geni through real Terraform** — dev-override binary, a `geni_profile` data source, and a deliberately expired cached token:

```
data.geni_profile.me: Read complete after 2s [id=profile-122248213]
```

No browser opened, and on disk both tokens rotated:

```
before:  access e17cf560f5a0   refresh d5c92a15b2ec   (expiry forced to 2000-01-01)
after :  access 870aab37b43b   refresh fbe35d60a13a   expiry +24h, mode 0600
```

## Also

`clientId` gives way to `geniapp.DefaultClientID` rather than being duplicated.
