### PR TITLE
ci: bump golangci-lint from v2.11.4 to v2.12.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Run linters
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.11.4
+          version: v2.12.2
 
   generate:
 


### PR DESCRIPTION
Keeps the pin current and aligned across the Go repos — go-geni is being pinned to the same version in a companion PR (it was floating on `latest`).

**Verified before opening:** ran golangci-lint v2.12.2 over `./...` locally — **0 issues**. A minor bump can enable new checks by default, so this was checked rather than assumed.