### PR TITLE
chore(deps): bump go-geni to v1.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## 0.26.1 (Unreleased)
 
+BUG FIXES:
+
+* Bump `github.com/dmalch/go-geni` to v1.29.0: a request blocked by Incapsula,
+  the DDoS protection in front of Geni, is now retried instead of failing the
+  resource on the first block. It was the last transient class that did not
+  recover — 429s, 401s, `502`/`503`/`504` and transient network errors were
+  already retried. Blocks get their own long backoff and a deliberately small
+  attempt budget, since retrying into bot protection can prolong it. A single
+  block during a large `terraform apply` no longer costs a whole re-plan and
+  re-apply round.
+
 ## 0.26.0
 
 FEATURES:

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/dmalch/terraform-provider-genealogy
 go 1.26
 
 require (
-	github.com/dmalch/go-geni v1.28.0
+	github.com/dmalch/go-geni v1.29.0
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/hashicorp/terraform-plugin-go v0.31.0

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dmalch/go-geni v1.28.0 h1:VIyFvmmT03CIAdZrI3nqr1I4z7YLKcd2xBH98Rj+siY=
-github.com/dmalch/go-geni v1.28.0/go.mod h1:FR7LU3f5Eni4497kkXBljkj+22EfznoAyJi4cMRQc+A=
+github.com/dmalch/go-geni v1.29.0 h1:G6c3Dj7rKW04hVCm4AfDvRslNvznQiuVgSGavCSjpsU=
+github.com/dmalch/go-geni v1.29.0/go.mod h1:FR7LU3f5Eni4497kkXBljkj+22EfznoAyJi4cMRQc+A=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=


### PR DESCRIPTION
Picks up the Incapsula retry fix — [dmalch/go-geni#86](https://github.com/dmalch/go-geni/pull/86), released as [v1.29.0](https://github.com/dmalch/go-geni/releases/tag/v1.29.0).

A request blocked by Incapsula (the DDoS protection in front of Geni) previously failed the resource on the **first** block: the error was a bare `fmt.Errorf`, so the retry predicate rejected it. It was the last transient class that did not recover — 429s, 401s, 502/503/504 and transient network errors were already retried.

Blocks now get their own long backoff and a deliberately small attempt budget, since retrying into bot protection can prolong it.

**Why it matters here:** during a recent apply over ~4900 profiles, one Incapsula block killed the Марьино apply outright and cost a full re-plan/re-apply round.

**Verified before opening:** `go build ./...`, `go vet ./...`, `go test ./...` and golangci-lint v2.12.2 — all clean.