### PR TITLE
chore: adopt modernize, and enable it

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,7 @@ linters:
     - intrange
     - makezero
     - misspell
+    - modernize
     - nilerr
     - nilnil
     - noctx

--- a/internal/datasource/project/convert_test.go
+++ b/internal/datasource/project/convert_test.go
@@ -14,7 +14,7 @@ func TestValueFrom(t *testing.T) {
 		givenResponse := &geniproject.Project{
 			ID:          "project-123",
 			Name:        "Test Project",
-			Description: ptr("This is a test project"),
+			Description: new("This is a test project"),
 			UpdatedAt:   "1719709400",
 			CreatedAt:   "1719709300",
 		}
@@ -47,8 +47,4 @@ func TestValueFrom(t *testing.T) {
 		Expect(model.Name.ValueString()).To(Equal("Minimal Project"))
 		Expect(model.Description.IsNull()).To(BeTrue())
 	})
-}
-
-func ptr[T any](s T) *T {
-	return &s
 }

--- a/internal/genibatch/batch_client.go
+++ b/internal/genibatch/batch_client.go
@@ -54,10 +54,10 @@ func (c *Client) GetUnion(ctx context.Context, id string) (*geniunion.Union, err
 	case res := <-response:
 		return res, nil
 	case err := <-errors:
-		tflog.Error(ctx, "Error processing request", map[string]interface{}{"error": err})
+		tflog.Error(ctx, "Error processing request", map[string]any{"error": err})
 		return nil, err
 	case <-ctx.Done():
-		tflog.Error(ctx, "Context done", map[string]interface{}{"error": ctx.Err()})
+		tflog.Error(ctx, "Context done", map[string]any{"error": ctx.Err()})
 		return nil, ctx.Err()
 	}
 }
@@ -76,10 +76,10 @@ func (c *Client) GetProfile(ctx context.Context, id string) (*geniprofile.Profil
 	case res := <-response:
 		return res, nil
 	case err := <-errors:
-		tflog.Error(ctx, "Error processing request", map[string]interface{}{"error": err})
+		tflog.Error(ctx, "Error processing request", map[string]any{"error": err})
 		return nil, err
 	case <-ctx.Done():
-		tflog.Error(ctx, "Context done", map[string]interface{}{"error": ctx.Err()})
+		tflog.Error(ctx, "Context done", map[string]any{"error": ctx.Err()})
 		return nil, ctx.Err()
 	}
 }
@@ -98,10 +98,10 @@ func (c *Client) GetDocument(ctx context.Context, id string) (*genidocument.Docu
 	case res := <-response:
 		return res, nil
 	case err := <-errors:
-		tflog.Error(ctx, "Error processing request", map[string]interface{}{"error": err})
+		tflog.Error(ctx, "Error processing request", map[string]any{"error": err})
 		return nil, err
 	case <-ctx.Done():
-		tflog.Error(ctx, "Context done", map[string]interface{}{"error": ctx.Err()})
+		tflog.Error(ctx, "Context done", map[string]any{"error": ctx.Err()})
 		return nil, ctx.Err()
 	}
 }
@@ -137,7 +137,7 @@ func (c *Client) UnionBulkProcessor(ctx context.Context) {
 		case <-ctx.Done():
 			err := ctx.Err()
 			if err != nil {
-				tflog.Error(ctx, "Context done", map[string]interface{}{"error": err})
+				tflog.Error(ctx, "Context done", map[string]any{"error": err})
 			}
 			return
 		}
@@ -173,7 +173,7 @@ func (c *Client) ProfileBulkProcessor(ctx context.Context) {
 		case <-ctx.Done():
 			err := ctx.Err()
 			if err != nil {
-				tflog.Error(ctx, "Context done", map[string]interface{}{"error": err})
+				tflog.Error(ctx, "Context done", map[string]any{"error": err})
 			}
 			return
 		}
@@ -209,7 +209,7 @@ func (c *Client) DocumentBulkProcessor(ctx context.Context) {
 		case <-ctx.Done():
 			err := ctx.Err()
 			if err != nil {
-				tflog.Error(ctx, "Context done", map[string]interface{}{"error": err})
+				tflog.Error(ctx, "Context done", map[string]any{"error": err})
 			}
 			return
 		}
@@ -230,7 +230,7 @@ func recoverBatch[T any](ctx context.Context, kind string, batch []asyncRequest[
 	}
 
 	err := fmt.Errorf("recovered from panic while processing %s batch: %v", kind, r)
-	tflog.Error(ctx, "Panic in batch processor", map[string]interface{}{"error": err})
+	tflog.Error(ctx, "Panic in batch processor", map[string]any{"error": err})
 
 	for _, req := range batch {
 		select {
@@ -435,10 +435,10 @@ func (c *Client) GetPhoto(ctx context.Context, id string) (*geniphoto.Photo, err
 	case res := <-response:
 		return res, nil
 	case err := <-errors:
-		tflog.Error(ctx, "Error processing request", map[string]interface{}{"error": err})
+		tflog.Error(ctx, "Error processing request", map[string]any{"error": err})
 		return nil, err
 	case <-ctx.Done():
-		tflog.Error(ctx, "Context done", map[string]interface{}{"error": ctx.Err()})
+		tflog.Error(ctx, "Context done", map[string]any{"error": ctx.Err()})
 		return nil, ctx.Err()
 	}
 }
@@ -472,7 +472,7 @@ func (c *Client) PhotoBulkProcessor(ctx context.Context) {
 		case <-ctx.Done():
 			err := ctx.Err()
 			if err != nil {
-				tflog.Error(ctx, "Context done", map[string]interface{}{"error": err})
+				tflog.Error(ctx, "Context done", map[string]any{"error": err})
 			}
 			return
 		}

--- a/internal/resource/document/convert_test.go
+++ b/internal/resource/document/convert_test.go
@@ -12,34 +12,30 @@ import (
 	"github.com/dmalch/terraform-provider-genealogy/internal/resource/event"
 )
 
-func ptr[T any](s T) *T {
-	return &s
-}
-
 func TestValueFrom(t *testing.T) {
 	t.Run("Happy path, when a fully defined object is passed", func(t *testing.T) {
 		RegisterTestingT(t)
 		givenResponse := genidocument.Document{
 			ID:          "123",
 			Title:       "Test Document",
-			Description: ptr("This is a test document"),
-			ContentType: ptr("text/plain"),
+			Description: new("This is a test document"),
+			ContentType: new("text/plain"),
 			Date: &geniprofile.DateElement{
-				Day:   ptr[int32](1),
-				Month: ptr[int32](1),
-				Year:  ptr[int32](2000),
+				Day:   new(int32(1)),
+				Month: new(int32(1)),
+				Year:  new(int32(2000)),
 			},
 			Location: &geniprofile.LocationElement{
-				City:           ptr("City"),
-				Country:        ptr("Country"),
-				County:         ptr("County"),
-				Latitude:       ptr(1.0),
-				Longitude:      ptr(2.0),
-				PlaceName:      ptr("Place Name"),
-				State:          ptr("State"),
-				StreetAddress1: ptr("Street Address 1"),
-				StreetAddress2: ptr("Street Address 2"),
-				StreetAddress3: ptr("Street Address 3"),
+				City:           new("City"),
+				Country:        new("Country"),
+				County:         new("County"),
+				Latitude:       new(1.0),
+				Longitude:      new(2.0),
+				PlaceName:      new("Place Name"),
+				State:          new("State"),
+				StreetAddress1: new("Street Address 1"),
+				StreetAddress2: new("Street Address 2"),
+				StreetAddress3: new("Street Address 3"),
 			},
 			Tags:      []string{"tag1", "tag2"},
 			Labels:    []string{"label1", "label2"},
@@ -132,7 +128,7 @@ func TestUpdateComputedFields(t *testing.T) {
 		RegisterTestingT(t)
 		givenResponse := &genidocument.Document{
 			ID:          "doc-123",
-			ContentType: ptr("text/plain"),
+			ContentType: new("text/plain"),
 			Tags:        []string{"profile-1"},
 			Labels:      []string{"label1"},
 			CreatedAt:   "1719709400",
@@ -161,7 +157,7 @@ func TestUpdateComputedFields(t *testing.T) {
 		RegisterTestingT(t)
 		givenResponse := &genidocument.Document{
 			ID:          "doc-new",
-			ContentType: ptr("text/html"),
+			ContentType: new("text/html"),
 			Tags:        []string{},
 			Labels:      []string{},
 			CreatedAt:   "1719709500",

--- a/internal/resource/document/list_test.go
+++ b/internal/resource/document/list_test.go
@@ -83,7 +83,7 @@ func TestBuildListResult(t *testing.T) {
 		givenResponse := &genidocument.Document{
 			ID:          "document-43",
 			Title:       "Birth Certificate",
-			ContentType: ptr("image/png"),
+			ContentType: new("image/png"),
 		}
 
 		result, ok := buildListResult(t.Context(), givenResponse, req)

--- a/internal/resource/event/convert_test.go
+++ b/internal/resource/event/convert_test.go
@@ -11,10 +11,6 @@ import (
 	geniprofile "github.com/dmalch/go-geni/profile"
 )
 
-func ptr[T any](s T) *T {
-	return &s
-}
-
 func TestElementFrom(t *testing.T) {
 	t.Run("regular case", func(t *testing.T) {
 		RegisterTestingT(t)
@@ -113,16 +109,16 @@ func TestValueFrom(t *testing.T) {
 		RegisterTestingT(t)
 		eventElement := &geniprofile.EventElement{
 			Name:        "Birth",
-			Description: ptr("Born in city"),
+			Description: new("Born in city"),
 			Date: &geniprofile.DateElement{
-				Circa: ptr(false),
-				Day:   ptr(int32(15)),
-				Month: ptr(int32(3)),
-				Year:  ptr(int32(1990)),
+				Circa: new(false),
+				Day:   new(int32(15)),
+				Month: new(int32(3)),
+				Year:  new(int32(1990)),
 			},
 			Location: &geniprofile.LocationElement{
-				City:    ptr("Springfield"),
-				Country: ptr("US"),
+				City:    new("Springfield"),
+				Country: new("US"),
 			},
 		}
 
@@ -167,7 +163,7 @@ func TestValueFrom(t *testing.T) {
 		RegisterTestingT(t)
 		eventElement := &geniprofile.EventElement{
 			Name: "Death of John Doe",
-			Date: &geniprofile.DateElement{Year: ptr(int32(1980))},
+			Date: &geniprofile.DateElement{Year: new(int32(1980))},
 		}
 
 		result, diags := ValueFrom(t.Context(), eventElement)
@@ -180,7 +176,7 @@ func TestValueFrom(t *testing.T) {
 		RegisterTestingT(t)
 		eventElement := &geniprofile.EventElement{
 			Name:     "Birth of John Doe",
-			Location: &geniprofile.LocationElement{City: ptr("Springfield")},
+			Location: &geniprofile.LocationElement{City: new("Springfield")},
 		}
 
 		result, diags := ValueFrom(t.Context(), eventElement)
@@ -194,10 +190,10 @@ func TestDateValueFrom(t *testing.T) {
 	t.Run("full date", func(t *testing.T) {
 		RegisterTestingT(t)
 		dateElement := &geniprofile.DateElement{
-			Circa: ptr(true),
-			Day:   ptr(int32(25)),
-			Month: ptr(int32(12)),
-			Year:  ptr(int32(1900)),
+			Circa: new(true),
+			Day:   new(int32(25)),
+			Month: new(int32(12)),
+			Year:  new(int32(1900)),
 		}
 
 		result, diags := DateValueFrom(t.Context(), dateElement)
@@ -228,15 +224,15 @@ func TestDateRangeValueFrom(t *testing.T) {
 	t.Run("full range date", func(t *testing.T) {
 		RegisterTestingT(t)
 		dateElement := &geniprofile.DateElement{
-			Range:    ptr("between"),
-			Circa:    ptr(true),
-			Day:      ptr(int32(1)),
-			Month:    ptr(int32(1)),
-			Year:     ptr(int32(1800)),
-			EndCirca: ptr(false),
-			EndDay:   ptr(int32(31)),
-			EndMonth: ptr(int32(12)),
-			EndYear:  ptr(int32(1850)),
+			Range:    new("between"),
+			Circa:    new(true),
+			Day:      new(int32(1)),
+			Month:    new(int32(1)),
+			Year:     new(int32(1800)),
+			EndCirca: new(false),
+			EndDay:   new(int32(31)),
+			EndMonth: new(int32(12)),
+			EndYear:  new(int32(1850)),
 		}
 
 		result, diags := DateRangeValueFrom(t.Context(), dateElement)
@@ -272,16 +268,16 @@ func TestLocationValueFrom(t *testing.T) {
 	t.Run("full location", func(t *testing.T) {
 		RegisterTestingT(t)
 		locationElement := &geniprofile.LocationElement{
-			City:           ptr("London"),
-			Country:        ptr("UK"),
-			County:         ptr("Greater London"),
-			Latitude:       ptr(51.5074),
-			Longitude:      ptr(-0.1278),
-			PlaceName:      ptr("Westminster"),
-			State:          ptr("England"),
-			StreetAddress1: ptr("10 Downing St"),
-			StreetAddress2: ptr("Suite 1"),
-			StreetAddress3: ptr("Floor 2"),
+			City:           new("London"),
+			Country:        new("UK"),
+			County:         new("Greater London"),
+			Latitude:       new(51.5074),
+			Longitude:      new(-0.1278),
+			PlaceName:      new("Westminster"),
+			State:          new("England"),
+			StreetAddress1: new("10 Downing St"),
+			StreetAddress2: new("Suite 1"),
+			StreetAddress3: new("Floor 2"),
 		}
 
 		result, diags := LocationValueFrom(t.Context(), locationElement)
@@ -434,7 +430,7 @@ func TestUpdateComputedFieldsInEvent(t *testing.T) {
 			})
 		eventElement := &geniprofile.EventElement{
 			Name:        "Marriage",
-			Description: ptr("Wedding ceremony"),
+			Description: new("Wedding ceremony"),
 		}
 
 		result, diags := UpdateComputedFieldsInEvent(t.Context(), eventObject, eventElement)
@@ -500,16 +496,16 @@ func TestUpdateComputedFieldsInLocationObject(t *testing.T) {
 				"street_address3": types.StringValue("Street Address 3"),
 			})
 		givenLocationResponse := &geniprofile.LocationElement{
-			City:           ptr("City Response"),
-			Country:        ptr("Country Response"),
-			County:         ptr("County Response"),
-			Latitude:       ptr(1.1),
-			Longitude:      ptr(2.1),
-			PlaceName:      ptr("Place Name Response"),
-			State:          ptr("State Response"),
-			StreetAddress1: ptr("Street Address 1 Response"),
-			StreetAddress2: ptr("Street Address 2 Response"),
-			StreetAddress3: ptr("Street Address 3 Response"),
+			City:           new("City Response"),
+			Country:        new("Country Response"),
+			County:         new("County Response"),
+			Latitude:       new(1.1),
+			Longitude:      new(2.1),
+			PlaceName:      new("Place Name Response"),
+			State:          new("State Response"),
+			StreetAddress1: new("Street Address 1 Response"),
+			StreetAddress2: new("Street Address 2 Response"),
+			StreetAddress3: new("Street Address 3 Response"),
 		}
 		updatedLocationObject, diags := UpdateComputedFieldsInLocationObject(t.Context(), givenLocationObject, givenLocationResponse)
 		Expect(diags).To(BeEmpty())
@@ -534,16 +530,16 @@ func TestUpdateComputedFieldsInLocationObject(t *testing.T) {
 				"street_address3": types.StringNull(),
 			})
 		givenLocationResponse := &geniprofile.LocationElement{
-			City:           ptr("City Response"),
-			Country:        ptr("Country Response"),
-			County:         ptr("County Response"),
-			Latitude:       ptr(1.1),
-			Longitude:      ptr(2.1),
-			PlaceName:      ptr("Place Name Response"),
-			State:          ptr("State Response"),
-			StreetAddress1: ptr("Street Address 1 Response"),
-			StreetAddress2: ptr("Street Address 2 Response"),
-			StreetAddress3: ptr("Street Address 3 Response"),
+			City:           new("City Response"),
+			Country:        new("Country Response"),
+			County:         new("County Response"),
+			Latitude:       new(1.1),
+			Longitude:      new(2.1),
+			PlaceName:      new("Place Name Response"),
+			State:          new("State Response"),
+			StreetAddress1: new("Street Address 1 Response"),
+			StreetAddress2: new("Street Address 2 Response"),
+			StreetAddress3: new("Street Address 3 Response"),
 		}
 		updatedLocationObject, diags := UpdateComputedFieldsInLocationObject(t.Context(), givenLocationObject, givenLocationResponse)
 		Expect(diags).To(BeEmpty())
@@ -573,16 +569,16 @@ func TestUpdateComputedFieldsInLocationObject(t *testing.T) {
 				"street_address3": types.StringNull(),
 			})
 		givenLocationResponse := &geniprofile.LocationElement{
-			City:           ptr("City Response"),
-			Country:        ptr("Country Response"),
-			County:         ptr("County Response"),
-			Latitude:       ptr(0.0),
-			Longitude:      ptr(0.0),
-			PlaceName:      ptr("Place Name Response"),
-			State:          ptr("State Response"),
-			StreetAddress1: ptr("Street Address 1 Response"),
-			StreetAddress2: ptr("Street Address 2 Response"),
-			StreetAddress3: ptr("Street Address 3 Response"),
+			City:           new("City Response"),
+			Country:        new("Country Response"),
+			County:         new("County Response"),
+			Latitude:       new(0.0),
+			Longitude:      new(0.0),
+			PlaceName:      new("Place Name Response"),
+			State:          new("State Response"),
+			StreetAddress1: new("Street Address 1 Response"),
+			StreetAddress2: new("Street Address 2 Response"),
+			StreetAddress3: new("Street Address 3 Response"),
 		}
 		updatedLocationObject, diags := UpdateComputedFieldsInLocationObject(t.Context(), givenLocationObject, givenLocationResponse)
 		Expect(diags).To(BeEmpty())

--- a/internal/resource/event/needs_date_prewipe_test.go
+++ b/internal/resource/event/needs_date_prewipe_test.go
@@ -1,6 +1,7 @@
 package event
 
 import (
+	"maps"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -124,9 +125,7 @@ func eventWithDate(fields map[string]attr.Value) types.Object {
 		"end_month": types.Int32Null(),
 		"end_year":  types.Int32Null(),
 	}
-	for k, v := range fields {
-		full[k] = v
-	}
+	maps.Copy(full, fields)
 	dateObj := types.ObjectValueMust(DateRangeModelAttributeTypes(), full)
 	return types.ObjectValueMust(EventModelAttributeTypes(), map[string]attr.Value{
 		"name":        types.StringNull(),

--- a/internal/resource/geniplanmodifier/values_are_removed_from_state.go
+++ b/internal/resource/geniplanmodifier/values_are_removed_from_state.go
@@ -2,6 +2,7 @@ package geniplanmodifier
 
 import (
 	"context"
+	"slices"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -24,10 +25,5 @@ func ValuesAreRemovedFromState(_ context.Context, req planmodifier.SetRequest, r
 }
 
 func contains(elements []attr.Value, v attr.Value) bool {
-	for _, p := range elements {
-		if v.Equal(p) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(elements, v.Equal)
 }

--- a/internal/resource/profile/convert_test.go
+++ b/internal/resource/profile/convert_test.go
@@ -11,30 +11,26 @@ import (
 	"github.com/dmalch/terraform-provider-genealogy/internal/resource/event"
 )
 
-func ptr[T any](s T) *T {
-	return &s
-}
-
 func TestValueFrom(t *testing.T) {
 	t.Run("Happy path, when a fully defined object is passed", func(t *testing.T) {
 		RegisterTestingT(t)
 		givenProfile := &geniprofile.Profile{
 			ID:          "123",
 			Guid:        "abcdef0123456789abcdef0123456789",
-			FirstName:   ptr("John"),
-			LastName:    ptr("Doe"),
-			MiddleName:  ptr("A"),
-			MaidenName:  ptr("Smith"),
-			DisplayName: ptr("John A Doe"),
-			Gender:      ptr("male"),
-			AboutMe:     ptr("This is a test profile"),
+			FirstName:   new("John"),
+			LastName:    new("Doe"),
+			MiddleName:  new("A"),
+			MaidenName:  new("Smith"),
+			DisplayName: new("John A Doe"),
+			Gender:      new("male"),
+			AboutMe:     new("This is a test profile"),
 			Public:      true,
 			IsAlive:     true,
 			Names: map[string]geniprofile.NameElement{
 				"en": {
-					FirstName:  ptr("John"),
-					MiddleName: ptr("A"),
-					LastName:   ptr("Doe"),
+					FirstName:  new("John"),
+					MiddleName: new("A"),
+					LastName:   new("Doe"),
 				},
 			},
 			Unions:     []string{"union1", "union2"},
@@ -44,30 +40,30 @@ func TestValueFrom(t *testing.T) {
 			Suffix:     "Jr.",
 			Birth: &geniprofile.EventElement{
 				Date: &geniprofile.DateElement{
-					Day:   ptr[int32](1),
-					Month: ptr[int32](1),
-					Year:  ptr[int32](2000),
+					Day:   new(int32(1)),
+					Month: new(int32(1)),
+					Year:  new(int32(2000)),
 				},
 			},
 			Baptism: &geniprofile.EventElement{
 				Date: &geniprofile.DateElement{
-					Day:   ptr[int32](1),
-					Month: ptr[int32](1),
-					Year:  ptr[int32](2000),
+					Day:   new(int32(1)),
+					Month: new(int32(1)),
+					Year:  new(int32(2000)),
 				},
 			},
 			Death: &geniprofile.EventElement{
 				Date: &geniprofile.DateElement{
-					Day:   ptr[int32](1),
-					Month: ptr[int32](1),
-					Year:  ptr[int32](2000),
+					Day:   new(int32(1)),
+					Month: new(int32(1)),
+					Year:  new(int32(2000)),
 				},
 			},
 			Burial: &geniprofile.EventElement{
 				Date: &geniprofile.DateElement{
-					Day:   ptr[int32](1),
-					Month: ptr[int32](1),
-					Year:  ptr[int32](2000),
+					Day:   new(int32(1)),
+					Month: new(int32(1)),
+					Year:  new(int32(2000)),
 				},
 			},
 			CreatedAt: "1719709400",
@@ -129,10 +125,10 @@ func TestValueFrom(t *testing.T) {
 		givenProfile := &geniprofile.Profile{
 			DetailStrings: map[string]geniprofile.DetailsString{
 				"en-US": {
-					AboutMe: ptr("This is a test profile in English"),
+					AboutMe: new("This is a test profile in English"),
 				},
 				"fr-FR": {
-					AboutMe: ptr("Ceci est un profil de test en français"),
+					AboutMe: new("Ceci est un profil de test en français"),
 				},
 			},
 		}
@@ -255,10 +251,10 @@ func TestUpdateComputedFields(t *testing.T) {
 			Projects: []string{"project-stale"},
 			Birth: &geniprofile.EventElement{
 				Name: "Birth",
-				Date: &geniprofile.DateElement{Year: ptr[int32](1990)},
+				Date: &geniprofile.DateElement{Year: new(int32(1990))},
 			},
 			DetailStrings: map[string]geniprofile.DetailsString{
-				"en-US": {AboutMe: ptr("Updated about")},
+				"en-US": {AboutMe: new("Updated about")},
 			},
 			Deleted:    true,
 			MergedInto: "profile-456",
@@ -412,8 +408,8 @@ func TestValueFromEdgeCases(t *testing.T) {
 		givenProfile := &geniprofile.Profile{
 			ID: "profile-details",
 			DetailStrings: map[string]geniprofile.DetailsString{
-				"en-US": {AboutMe: ptr("English bio")},
-				"de-DE": {AboutMe: ptr("German bio")},
+				"en-US": {AboutMe: new("English bio")},
+				"de-DE": {AboutMe: new("German bio")},
 			},
 		}
 
@@ -434,38 +430,38 @@ func TestNameValueFrom(t *testing.T) {
 		RegisterTestingT(t)
 		givenNames := map[string]geniprofile.NameElement{
 			"en": {
-				FirstName:   ptr("John"),
-				MiddleName:  ptr("A"),
-				LastName:    ptr("Doe"),
-				MaidenName:  ptr("Smith"),
-				DisplayName: ptr("John A Doe"),
-				Nicknames:   ptr("A,B"),
+				FirstName:   new("John"),
+				MiddleName:  new("A"),
+				LastName:    new("Doe"),
+				MaidenName:  new("Smith"),
+				DisplayName: new("John A Doe"),
+				Nicknames:   new("A,B"),
 			},
 			"fr": {
-				FirstName:   ptr("Jean"),
-				MiddleName:  ptr("B"),
-				LastName:    ptr("Dupont"),
-				MaidenName:  ptr("Bernard"),
-				DisplayName: ptr("Jean B Bernard"),
-				Nicknames:   ptr("C,D"),
+				FirstName:   new("Jean"),
+				MiddleName:  new("B"),
+				LastName:    new("Dupont"),
+				MaidenName:  new("Bernard"),
+				DisplayName: new("Jean B Bernard"),
+				Nicknames:   new("C,D"),
 			},
 		}
 
 		expectedNames := map[string]NameModel{
 			"en": {
-				FirstName:     types.StringPointerValue(ptr("John")),
-				MiddleName:    types.StringPointerValue(ptr("A")),
-				LastName:      types.StringPointerValue(ptr("Doe")),
-				BirthLastName: types.StringPointerValue(ptr("Smith")),
-				DisplayName:   types.StringPointerValue(ptr("John A Doe")),
+				FirstName:     types.StringPointerValue(new("John")),
+				MiddleName:    types.StringPointerValue(new("A")),
+				LastName:      types.StringPointerValue(new("Doe")),
+				BirthLastName: types.StringPointerValue(new("Smith")),
+				DisplayName:   types.StringPointerValue(new("John A Doe")),
 				Nicknames:     types.SetValueMust(types.StringType, []attr.Value{types.StringValue("A"), types.StringValue("B")}),
 			},
 			"fr": {
-				FirstName:     types.StringPointerValue(ptr("Jean")),
-				MiddleName:    types.StringPointerValue(ptr("B")),
-				LastName:      types.StringPointerValue(ptr("Dupont")),
-				BirthLastName: types.StringPointerValue(ptr("Bernard")),
-				DisplayName:   types.StringPointerValue(ptr("Jean B Bernard")),
+				FirstName:     types.StringPointerValue(new("Jean")),
+				MiddleName:    types.StringPointerValue(new("B")),
+				LastName:      types.StringPointerValue(new("Dupont")),
+				BirthLastName: types.StringPointerValue(new("Bernard")),
+				DisplayName:   types.StringPointerValue(new("Jean B Bernard")),
 				Nicknames:     types.SetValueMust(types.StringType, []attr.Value{types.StringValue("C"), types.StringValue("D")}),
 			},
 		}
@@ -485,11 +481,11 @@ func TestNamesWithFlatFallback(t *testing.T) {
 	t.Run("Returns the API names map as-is when it has entries", func(t *testing.T) {
 		RegisterTestingT(t)
 		original := map[string]geniprofile.NameElement{
-			"fr": {FirstName: ptr("Jean"), LastName: ptr("Dupont")},
+			"fr": {FirstName: new("Jean"), LastName: new("Dupont")},
 		}
 		profile := &geniprofile.Profile{
 			Names:     original,
-			FirstName: ptr("ignored-because-map-is-populated"),
+			FirstName: new("ignored-because-map-is-populated"),
 		}
 
 		result := namesWithFlatFallback(profile)
@@ -500,11 +496,11 @@ func TestNamesWithFlatFallback(t *testing.T) {
 	t.Run("Synthesizes an en-US entry from flat fields when the map is empty", func(t *testing.T) {
 		RegisterTestingT(t)
 		profile := &geniprofile.Profile{
-			FirstName:   ptr("John"),
-			MiddleName:  ptr("A"),
-			LastName:    ptr("Doe"),
-			MaidenName:  ptr("Smith"),
-			DisplayName: ptr("John A Doe"),
+			FirstName:   new("John"),
+			MiddleName:  new("A"),
+			LastName:    new("Doe"),
+			MaidenName:  new("Smith"),
+			DisplayName: new("John A Doe"),
 		}
 
 		result := namesWithFlatFallback(profile)
@@ -522,7 +518,7 @@ func TestNamesWithFlatFallback(t *testing.T) {
 	t.Run("Joins flat nicknames into a comma-separated string", func(t *testing.T) {
 		RegisterTestingT(t)
 		profile := &geniprofile.Profile{
-			FirstName: ptr("John"),
+			FirstName: new("John"),
 			Nicknames: []string{"Johnny", "JD"},
 		}
 
@@ -564,8 +560,8 @@ func TestValueFrom_NamesFlatFallback(t *testing.T) {
 		givenResponse := &geniprofile.Profile{
 			ID:        "profile-42",
 			Public:    true,
-			FirstName: ptr("John"),
-			LastName:  ptr("Doe"),
+			FirstName: new("John"),
+			LastName:  new("Doe"),
 		}
 
 		var model ResourceModel
@@ -586,10 +582,10 @@ func TestValueFrom_NamesFlatFallback(t *testing.T) {
 		givenResponse := &geniprofile.Profile{
 			ID:        "profile-43",
 			Public:    true,
-			FirstName: ptr("ignored"),
-			LastName:  ptr("ignored"),
+			FirstName: new("ignored"),
+			LastName:  new("ignored"),
 			Names: map[string]geniprofile.NameElement{
-				"fr": {FirstName: ptr("Jean"), LastName: ptr("Dupont")},
+				"fr": {FirstName: new("Jean"), LastName: new("Dupont")},
 			},
 		}
 

--- a/internal/resource/profile/list_test.go
+++ b/internal/resource/profile/list_test.go
@@ -41,8 +41,8 @@ func TestDisplayNameFor(t *testing.T) {
 		RegisterTestingT(t)
 		got := displayNameFor(&geniprofile.Profile{
 			ID:        "profile-1",
-			FirstName: ptr("John"),
-			LastName:  ptr("Doe"),
+			FirstName: new("John"),
+			LastName:  new("Doe"),
 		})
 		Expect(got).To(Equal("John Doe (profile-1)"))
 	})
@@ -52,8 +52,8 @@ func TestDisplayNameFor(t *testing.T) {
 		got := displayNameFor(&geniprofile.Profile{
 			ID: "profile-2",
 			Names: map[string]geniprofile.NameElement{
-				"fr":    {FirstName: ptr("Jean"), LastName: ptr("Dupont")},
-				"en-US": {FirstName: ptr("John"), LastName: ptr("Doe")},
+				"fr":    {FirstName: new("Jean"), LastName: new("Dupont")},
+				"en-US": {FirstName: new("John"), LastName: new("Doe")},
 			},
 		})
 		Expect(got).To(Equal("John Doe (profile-2)"))
@@ -70,7 +70,7 @@ func TestBuildListResult(t *testing.T) {
 	t.Run("Populates Identity with the profile ID", func(t *testing.T) {
 		RegisterTestingT(t)
 		req := listRequest(t, false)
-		givenResponse := &geniprofile.Profile{ID: "profile-42", FirstName: ptr("John"), LastName: ptr("Doe")}
+		givenResponse := &geniprofile.Profile{ID: "profile-42", FirstName: new("John"), LastName: new("Doe")}
 
 		result, ok := buildListResult(t.Context(), givenResponse, req)
 
@@ -86,7 +86,7 @@ func TestBuildListResult(t *testing.T) {
 	t.Run("Sets a human-readable DisplayName", func(t *testing.T) {
 		RegisterTestingT(t)
 		req := listRequest(t, false)
-		givenResponse := &geniprofile.Profile{ID: "profile-42", FirstName: ptr("John"), LastName: ptr("Doe")}
+		givenResponse := &geniprofile.Profile{ID: "profile-42", FirstName: new("John"), LastName: new("Doe")}
 
 		result, ok := buildListResult(t.Context(), givenResponse, req)
 
@@ -100,8 +100,8 @@ func TestBuildListResult(t *testing.T) {
 		givenResponse := &geniprofile.Profile{
 			ID:        "profile-43",
 			Public:    true,
-			FirstName: ptr("John"),
-			LastName:  ptr("Doe"),
+			FirstName: new("John"),
+			LastName:  new("Doe"),
 		}
 
 		result, ok := buildListResult(t.Context(), givenResponse, req)
@@ -123,7 +123,7 @@ func TestBuildListResult(t *testing.T) {
 	t.Run("Leaves Resource at its schema-null default when IncludeResource is false", func(t *testing.T) {
 		RegisterTestingT(t)
 		req := listRequest(t, false)
-		givenResponse := &geniprofile.Profile{ID: "profile-44", FirstName: ptr("John"), LastName: ptr("Doe")}
+		givenResponse := &geniprofile.Profile{ID: "profile-44", FirstName: new("John"), LastName: new("Doe")}
 
 		result, ok := buildListResult(t.Context(), givenResponse, req)
 

--- a/internal/resource/union/convert_test.go
+++ b/internal/resource/union/convert_test.go
@@ -13,10 +13,6 @@ import (
 	"github.com/dmalch/terraform-provider-genealogy/internal/tfset"
 )
 
-func ptr[T any](s T) *T {
-	return &s
-}
-
 func TestValueFrom(t *testing.T) {
 	t.Run("Happy path, when a fully defined union response is passed", func(t *testing.T) {
 		RegisterTestingT(t)
@@ -27,21 +23,21 @@ func TestValueFrom(t *testing.T) {
 			Marriage: &geniprofile.EventElement{
 				Name: "Marriage",
 				Date: &geniprofile.DateElement{
-					Day:   ptr[int32](15),
-					Month: ptr[int32](6),
-					Year:  ptr[int32](1990),
+					Day:   new(int32(15)),
+					Month: new(int32(6)),
+					Year:  new(int32(1990)),
 				},
 				Location: &geniprofile.LocationElement{
-					City:    ptr("Paris"),
-					Country: ptr("France"),
+					City:    new("Paris"),
+					Country: new("France"),
 				},
 			},
 			Divorce: &geniprofile.EventElement{
 				Name: "Divorce",
 				Date: &geniprofile.DateElement{
-					Day:   ptr[int32](1),
-					Month: ptr[int32](3),
-					Year:  ptr[int32](2000),
+					Day:   new(int32(1)),
+					Month: new(int32(3)),
+					Year:  new(int32(2000)),
 				},
 			},
 		}
@@ -242,18 +238,18 @@ func TestUpdateComputedFields(t *testing.T) {
 			ID: "union-123",
 			Marriage: &geniprofile.EventElement{
 				Name:        "Marriage",
-				Description: ptr("A beautiful ceremony"),
+				Description: new("A beautiful ceremony"),
 				Date: &geniprofile.DateElement{
-					Year: ptr[int32](1990),
+					Year: new(int32(1990)),
 				},
 				Location: &geniprofile.LocationElement{
-					City: ptr("Paris"),
+					City: new("Paris"),
 				},
 			},
 			Divorce: &geniprofile.EventElement{
 				Name: "Divorce",
 				Date: &geniprofile.DateElement{
-					Year: ptr[int32](2000),
+					Year: new(int32(2000)),
 				},
 			},
 		}
@@ -261,12 +257,12 @@ func TestUpdateComputedFields(t *testing.T) {
 		// Create a model with existing event objects that have unknown computed fields
 		marriageObj, _ := event.ValueFrom(t.Context(), &geniprofile.EventElement{
 			Date: &geniprofile.DateElement{
-				Year: ptr[int32](1990),
+				Year: new(int32(1990)),
 			},
 		})
 		divorceObj, _ := event.ValueFrom(t.Context(), &geniprofile.EventElement{
 			Date: &geniprofile.DateElement{
-				Year: ptr[int32](2000),
+				Year: new(int32(2000)),
 			},
 		})
 

--- a/internal/resource/union/read.go
+++ b/internal/resource/union/read.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -122,10 +123,8 @@ func (r *Resource) findExistingUnionForPartners(ctx context.Context, partners ty
 				}
 
 				// Check if the profile is a partner in the union
-				for _, partnerId := range unionResponse.Partners {
-					if partnerId == profileResponse.ID {
-						return unionId, diags
-					}
+				if slices.Contains(unionResponse.Partners, profileResponse.ID) {
+					return unionId, diags
 				}
 			}
 

--- a/internal/resource/union/temp_profile.go
+++ b/internal/resource/union/temp_profile.go
@@ -32,7 +32,7 @@ func (r *Resource) addAndMerge(
 	if _, err := r.client.Profile().Merge(ctx, realID, tmp.ID); err != nil {
 		if delErr := r.client.Profile().Delete(ctx, tmp.ID); delErr != nil {
 			tflog.Error(ctx, "failed to delete orphan temporary profile after a failed merge",
-				map[string]interface{}{"profile_id": tmp.ID, "error": delErr})
+				map[string]any{"profile_id": tmp.ID, "error": delErr})
 		}
 		return tmp, err
 	}


### PR DESCRIPTION
`modernize` is available in golangci-lint but was not enabled. Turning it on found 164 things.

## Non-test changes (17)

- `interface{}` → `any` in the `tflog` call sites (14)
- `slices.Contains` / `slices.ContainsFunc` replacing hand-rolled search loops (2). The union lookup keeps its early return — only the loop goes.
- one maps loop replaced by the stdlib equivalent

## Test changes (173)

The generic `ptr()` helper is gone from all five packages, replaced by Go 1.26's `new(expr)`.

**This part needed hand-finishing, and is worth a look.** The auto-fix:

- rewrote the inferred `ptr(x)` calls but **not** the explicitly instantiated `ptr[int32](1)` — `new()` infers from its argument, so those had to become `new(int32(1))` by hand (26 sites);
- marked each helper `//go:fix inline` instead of deleting it, which left **two packages with a dead helper** (`unused`) and **three whose callers `govet` then wanted inlined** (26 warnings).

Taking the auto-fix as-is would have shipped a half-applied migration with a red CI. All five helpers and the injected directives are now removed.

## Why enable it

A one-off cleanup silently regresses. Same class as `exptostd`, already enabled here.

Clean at v2.12.2; `go build` and the full test suite pass.