### PR TITLE
fix(profile): link only the projects an update ADDS

### DIFF
--- a/internal/resource/profile/update.go
+++ b/internal/resource/profile/update.go
@@ -44,11 +44,19 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		}
 	}
 
-	projectIds, diags := tfset.Strings(ctx, plan.Projects)
+	planProjectIds, diags := tfset.Strings(ctx, plan.Projects)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	stateProjectIds, diags := tfset.Strings(ctx, state.Projects)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	projectIds := addedProjects(stateProjectIds, planProjectIds)
 
 	// Geni's PATCH deep-merges nested objects per-key, so clearing individual
 	// date sub-fields needs a wipe-then-rewrite (#94). Issue the pre-wipe only
@@ -67,7 +75,7 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		return
 	}
 
-	// Link the profile to the projects if specified.
+	// Link the profile to the projects the plan ADDS. See addedProjects.
 	for _, projectId := range projectIds {
 		if _, err := r.client.Project().AddProfile(ctx, profileResponse.ID, projectId); err != nil {
 			resp.Diagnostics.AddError("Error linking profile to project", err.Error())
@@ -86,6 +94,43 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 	// Set data returned by API in identity
 	identityData.ID = types.StringValue(profileResponse.ID)
 	resp.Diagnostics.Append(resp.Identity.Set(ctx, identityData)...)
+}
+
+// addedProjects returns the project ids the plan introduces — those not already
+// linked in state.
+//
+// Re-asserting an EXISTING link is not a harmless no-op at the API. AddProfile
+// is a write only the project's owner may perform, so re-sending a membership
+// somebody else created fails with "access denied" and fails the whole update
+// with it — even though the profile itself updated fine moments earlier.
+//
+// This is not hypothetical. A Нижняя Верея ancestor belongs to the public
+// "Memorial: USSR political terror victims" project (project-28427), added
+// there by Memorial's own curators. Terraform reads that membership on refresh,
+// so it sits in both state and plan, and before this every later edit to the
+// profile re-sent the link and errored. The profile's own update had already
+// succeeded, which made the failure read as data loss when it was not.
+//
+// Create still links every project in the plan, correctly: a profile that did
+// not exist a moment ago has no memberships to re-assert.
+//
+// Note this does not UNLINK projects the plan drops — Update never has, and
+// changing that is a separate decision about who owns the field.
+func addedProjects(state, plan []string) []string {
+	linked := tfset.Index(state)
+
+	var added []string
+	for _, id := range plan {
+		if _, exists := linked[id]; !exists {
+			added = append(added, id)
+			// Fold it in so a repeated id is not linked twice. plan.Projects
+			// is a Set today, so this cannot bite from the Update path — but
+			// the signature takes a slice, and one link op per id is the
+			// contract regardless of who calls it.
+			linked[id] = struct{}{}
+		}
+	}
+	return added
 }
 
 // planDateWipes lists the event keys whose date sub-object the Update path

--- a/internal/resource/profile/update_test.go
+++ b/internal/resource/profile/update_test.go
@@ -1,0 +1,63 @@
+package profile
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestAddedProjects(t *testing.T) {
+	t.Run("an unchanged membership is not re-linked", func(t *testing.T) {
+		RegisterTestingT(t)
+
+		// The regression this exists for. AddProfile is a write only the
+		// project's OWNER may perform, so re-sending a membership somebody
+		// else created fails with "access denied" and fails the whole update
+		// — after the profile itself already updated successfully.
+		linked := []string{"project-28427", "project-4505748", "project-4518482"}
+
+		Expect(addedProjects(linked, linked)).To(BeEmpty())
+	})
+
+	t.Run("only the newly added project is linked", func(t *testing.T) {
+		RegisterTestingT(t)
+
+		added := addedProjects(
+			[]string{"project-4505748"},
+			[]string{"project-4505748", "project-4518482"},
+		)
+
+		Expect(added).To(ConsistOf("project-4518482"))
+	})
+
+	t.Run("every project is linked when state has none", func(t *testing.T) {
+		RegisterTestingT(t)
+
+		added := addedProjects(nil, []string{"project-4505748", "project-4518482"})
+
+		Expect(added).To(ConsistOf("project-4505748", "project-4518482"))
+	})
+
+	t.Run("a dropped project is not unlinked", func(t *testing.T) {
+		RegisterTestingT(t)
+
+		// Update has never unlinked, and this change deliberately does not
+		// start: who owns the field is a separate decision.
+		added := addedProjects(
+			[]string{"project-4505748", "project-4518482"},
+			[]string{"project-4505748"},
+		)
+
+		Expect(added).To(BeEmpty())
+	})
+
+	t.Run("duplicates in the plan are linked once", func(t *testing.T) {
+		RegisterTestingT(t)
+
+		added := addedProjects(nil, []string{"project-4518482", "project-4518482"})
+
+		// tfset.Index collapses duplicates, but the plan side is a list — a
+		// repeated id would otherwise be sent twice.
+		Expect(added).To(HaveLen(1))
+	})
+}


### PR DESCRIPTION
`Update` re-sent **every** project link on **every** update, without diffing against state:

```go
// before — internal/resource/profile/update.go
projectIds, _ := tfset.Strings(ctx, plan.Projects)
...
for _, projectId := range projectIds {
    r.client.Project().AddProfile(ctx, profileResponse.ID, projectId)
}
```

`AddProfile` is a write only the project's **owner** may perform. Re-asserting a membership somebody else created fails with `access denied` — and fails the whole update with it, moments after the profile itself updated successfully.

### How it showed up

A Нижняя Верея ancestor belongs to the public **Memorial: USSR political terror victims** project (`project-28427`), added there by Memorial's own curators. Terraform reads that membership on refresh, so it sits in **both state and plan with no diff** — and every later edit to the profile re-sent the link and errored:

```
Error: Error linking profile to project
  with geni_profile.vasilij_andreevich_ladugin
  All attempts fail:
  #1: access denied
```

Note the single attempt — `access denied` is not retryable, so this is structural, not flaky. Any profile in any project we do not own hits it on every single change.

It also reads worse than it is: the profile update had **already landed**. Confirmed on `profile-34697584214`, whose new about text was live on Geni despite the error. So an apply reports failure for work that succeeded.

### The fix

Link only `plan − state`. `Create` is untouched and still links everything in the plan, which is correct — a profile that did not exist a moment ago has no memberships to re-assert.

### Deliberately not changed

`Update` still does not **unlink** projects the plan drops. It never has, and who owns that field is a separate decision — worth its own issue rather than smuggling into a bugfix.

### Tests

`addedProjects` covering: unchanged membership → nothing linked (the regression), only-the-new-one linked, empty state links everything, a dropped project is not unlinked, and repeated ids link once. The last one caught a real gap in my first attempt — `plan.Projects` is a `types.Set` so duplicates cannot occur from this call site, but the helper takes a slice and one link op per id is the contract regardless of caller.

Draft pending your review of whether the unlink question should be handled here or separately.